### PR TITLE
Main improment

### DIFF
--- a/lib/src/controllers/mqtt/mqtt_controller.dart
+++ b/lib/src/controllers/mqtt/mqtt_controller.dart
@@ -672,6 +672,7 @@ class IsmLiveMqttController extends GetxController {
           final initiatorName = payload['initiatorName'] as String? ?? '';
           final initiatorId = payload['initiatorId'] as String? ?? '';
           if (streamId == _streamController.streamId) {
+            _syncLiveViewersCountFromPayload(payload);
             final message = IsmLiveMessageModel(
               streamId: streamId!,
               senderName: initiatorName,
@@ -689,14 +690,30 @@ class IsmLiveMqttController extends GetxController {
             _streamController.streamMembersList
                 .removeWhere((e) => e.userId == memberId);
             if (userId != initiatorId && userId == memberId) {
-              await _streamController.disconnectRoom();
-              IsmLiveRoute.pop();
+              final rejoinAsViewer = _streamController.isCopublisher &&
+                  !_streamController.isHost;
+              if (rejoinAsViewer) {
+                final ok = await _streamController
+                    .rejoinAsViewerAfterHostRemovedCopublisher(
+                  streamId: streamId,
+                );
+                if (!ok) {
+                  await _streamController.disconnectRoom();
+                  IsmLiveRoute.pop();
+                }
+              } else {
+                await _streamController.disconnectRoom();
+                IsmLiveRoute.pop();
+              }
             }
             await Future.delayed(const Duration(milliseconds: 300));
             _updateStream();
           }
           break;
         case IsmLiveActions.profileSwitched:
+          if (streamId == _streamController.streamId) {
+            _syncLiveViewersCountFromPayload(payload);
+          }
           final memberId = payload['userId'] as String? ?? '';
           final memberName = payload['userName'] as String? ?? '';
           var body = '';

--- a/lib/src/controllers/stream/mixins/join_mixin.dart
+++ b/lib/src/controllers/stream/mixins/join_mixin.dart
@@ -1288,6 +1288,106 @@ mixin StreamJoinMixin {
     }
   }
 
+  /// Host removed this device user from co-publishers (MQTT `memberRemoved`).
+  /// The backend already cleared the member role; mirror successful `leaveMember` local
+  /// cleanup then reconnect as a viewer (same RTC path as `leaveCopublisherAndRejoinAsViewer`).
+  ///
+  /// Returns whether LiveKit reports connected after reconnect. On `false`, callers
+  /// may fall back to leaving the stream UI (e.g. disconnect room + pop).
+  Future<bool> rejoinAsViewerAfterHostRemovedCopublisher({
+    required String streamId,
+  }) async {
+    if (_controller.isHost || !_controller.isCopublisher) {
+      return false;
+    }
+
+    final context = IsmLiveUtility.navigatorKey.currentContext;
+    if (context == null) {
+      IsmLiveLog.error(
+          'rejoinAsViewerAfterHostRemovedCopublisher: navigator context is null');
+      return false;
+    }
+
+    try {
+      await _controller.room?.localParticipant?.unpublishAllTracks();
+    } catch (_) {}
+    try {
+      _controller.userRole?.leaveCopublishing();
+      _controller.memberStatus = IsmLiveMemberStatus.notMember;
+    } catch (_) {}
+    try {
+      await _controller.sortParticipants();
+    } catch (_) {}
+    _controller.update([IsmLiveMembersSheet.updateId]);
+
+    var loaderShown = false;
+    try {
+      _controller.isViewerJoiningStream = true;
+      _controller.preventDispose = true;
+
+      if (!(Get.isDialogOpen ?? false)) {
+        IsmLiveUtility.showLoader();
+        loaderShown = true;
+      }
+
+      final rtc = await _controller.getRTCToken(streamId);
+      if (rtc == null || rtc.rtcToken.trim().isEmpty) {
+        IsmLiveLog.error(
+            'rejoinAsViewerAfterHostRemovedCopublisher: RTC token fetch failed');
+        return false;
+      }
+
+      final token = rtc.rtcToken;
+      _controller.rtcToken = token;
+      _controller.storeToken(token);
+
+      final details = _controller.streamDetails;
+      await _connectRoomAndInitialize(
+        stream: details,
+        token: token,
+        streamId: streamId,
+        streamImage: details?.streamImage,
+        streamDiscription: details?.streamDescription ??
+            _controller.descriptionController.text,
+        hdBroadcast: details?.hdBroadcast ?? _controller.isHdBroadcast,
+        restream: details?.restream ?? _controller.isRestreamBroadcast,
+        isHost: false,
+        isCopublisher: false,
+        isPk: details?.isPkChallenge ?? false,
+        isPkGust: false,
+        isNewStream: false,
+        joinByScrolling: false,
+        isScrolling: false,
+        isInteractive: false,
+        startTime: rtc.startTime ?? details?.startDateTime,
+        context: context,
+        eventId: details?.eventId,
+        reJoin: true,
+        isScheduledStream: details?.isScheduledStream,
+        products: details?.products,
+        performNavigation: false,
+        showLoader: false,
+      );
+
+      await Future.delayed(const Duration(milliseconds: 150));
+      final connected =
+          _controller.room?.connectionState == lk.ConnectionState.connected;
+      IsmLiveLog.info(
+          'rejoinAsViewerAfterHostRemovedCopublisher: connected=$connected state=${_controller.room?.connectionState}');
+      return connected;
+    } catch (e, st) {
+      IsmLiveLog.error(
+          'rejoinAsViewerAfterHostRemovedCopublisher: unexpected error: $e', st);
+      return false;
+    } finally {
+      if (loaderShown) {
+        IsmLiveUtility.closeLoader();
+      }
+      _controller.isViewerJoiningStream = false;
+      _controller.preventDispose = false;
+    }
+  }
+
   /// Copublisher: rejoin the currently open stream after app resumes.
   ///
   /// Reuses the stored RTC token (saved via `storeToken` when the copublisher

--- a/lib/src/views/stream/stream_view.dart
+++ b/lib/src/views/stream/stream_view.dart
@@ -885,6 +885,7 @@ class _StreamHeader extends StatelessWidget {
   Widget build(BuildContext context) => GetBuilder<IsmLiveStreamController>(
         id: IsmLiveStreamView.updateId,
         builder: (controller) => SafeArea(
+          bottom: false,
           child: IsmLiveStreamHeader(
             streamCoins: controller.premiumStreamCoinsController.text,
             isBattleTie: controller.pkWinnerId != null,

--- a/lib/src/views/stream/widgets/dialogs/schedule_dialog.dart
+++ b/lib/src/views/stream/widgets/dialogs/schedule_dialog.dart
@@ -26,11 +26,11 @@ class IsmLiveScheduleDialog extends StatelessWidget {
         ),
         IsmLiveDimens.boxHeight8,
         Text(
-          'at ${message.formattedDate}',
+          'At ${message.formattedDate}',
           style: context.textTheme.bodyMedium?.copyWith(color: textColor),
         ),
         IsmLiveDimens.boxHeight20,
-        IsmLiveButton(
+        const IsmLiveButton(
           label: IsmLiveStrings.tvContinue,
           onTap: IsmLiveUtility.closeDialog,
         ),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces improvements to handle live stream viewer synchronization and stream rejoining logic. Specifically, it adds functionality to update the live viewers count based on incoming payloads, and implements a mechanism for a device to rejoin a stream as a viewer after the host removes a co-publisher. Additionally, it adjusts UI elements for better layout and fixes text styling in the schedule dialog. Overall, these changes enhance the robustness of stream participant management and improve user interface consistency during live streams.
<!-- kody-pr-summary:end -->