### PR TITLE
Fix: Reset button getting crop in IOS

### DIFF
--- a/lib/src/utils/file_manager.dart
+++ b/lib/src/utils/file_manager.dart
@@ -4,6 +4,14 @@ import 'package:file_picker/file_picker.dart';
 import 'package:image_cropper/image_cropper.dart';
 import 'package:image_picker/image_picker.dart';
 
+class CropAspectRatioPresetCustom implements CropAspectRatioPresetData {
+  @override
+  (int, int)? get data => (9, 16);
+
+  @override
+  String get name => '9x16 (customized)';
+}
+
 class FileManager {
   const FileManager._();
 
@@ -103,7 +111,12 @@ class FileManager {
           lockAspectRatio: true,
           cropStyle: CropStyle.rectangle,
         ),
-        IOSUiSettings(title: 'Cropper', cropStyle: CropStyle.rectangle)
+        IOSUiSettings(title: 'Cropper', // cropStyle: CropStyle.rectangle,
+          aspectRatioPresets: [
+            CropAspectRatioPreset.original,
+            CropAspectRatioPreset.square,
+            CropAspectRatioPresetCustom(),
+          ],)
       ],
     );
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a custom crop aspect ratio preset for image cropping, specifically a 9:16 ratio labeled as "9x16 (customized)". It updates the cropping UI on iOS to include this new aspect ratio option, allowing users to select a fixed 9:16 crop ratio during image editing. This enhancement provides more flexible and tailored cropping options within the app's image management features.
<!-- kody-pr-summary:end -->