### PR TITLE
Fix: StreamEndView showing two times race condition managed

### DIFF
--- a/lib/src/controllers/stream/mixins/ongoing_mixin.dart
+++ b/lib/src/controllers/stream/mixins/ongoing_mixin.dart
@@ -1605,6 +1605,12 @@ mixin StreamOngoingMixin {
   }
 
   void closeStreamView(bool isHost, {String? streamId, bool fromMqtt = false}) {
+    if (!_controller.tryMarkStreamViewClosed()) {
+      IsmLiveLog(
+          'closeStreamView skipped: already handled for current stream lifecycle');
+      return;
+    }
+
     _controller.streamTimer?.cancel();
     _controller.streamTimer = null;
     _pkController.pkTimer?.cancel();

--- a/lib/src/controllers/stream/stream_controller.dart
+++ b/lib/src/controllers/stream/stream_controller.dart
@@ -201,6 +201,7 @@ class IsmLiveStreamController extends GetxController
 
   bool _streamViewLoadedCallbackTriggered = false;
   bool _hasTriggeredOnStreamEnd = false;
+  bool _hasClosedStreamView = false;
 
   /// Ensures `onStreamEnd` callback is emitted only once per stream lifecycle.
   void triggerOnStreamEndOnce() {
@@ -214,6 +215,17 @@ class IsmLiveStreamController extends GetxController
   /// Resets single-fire guard for new join lifecycle.
   void resetOnStreamEndTrigger() {
     _hasTriggeredOnStreamEnd = false;
+    _hasClosedStreamView = false;
+  }
+
+  /// Marks stream view as closed once per lifecycle.
+  /// Returns false when close flow has already executed.
+  bool tryMarkStreamViewClosed() {
+    if (_hasClosedStreamView) {
+      return false;
+    }
+    _hasClosedStreamView = true;
+    return true;
   }
 
   Uint8List? bytes;


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request addresses a race condition in the `StreamEndView` display logic by ensuring it is only shown once per stream lifecycle. It introduces a guard mechanism that prevents multiple invocations of the stream view closing process, thereby avoiding duplicate UI displays. The changes include adding a boolean flag `_hasClosedStreamView` in the stream controller to track whether the stream view has already been closed, and a method `tryMarkStreamViewClosed()` to manage this state. The `closeStreamView` method now checks this guard before proceeding, ensuring the stream end view is only handled a single time, which stabilizes the user experience and prevents race conditions related to stream termination.
<!-- kody-pr-summary:end -->