### PR TITLE
Fix: Enhanced Auto-reconnect MQTT flow

### DIFF
--- a/lib/src/controllers/mqtt/mqtt_controller.dart
+++ b/lib/src/controllers/mqtt/mqtt_controller.dart
@@ -243,6 +243,8 @@ class IsmLiveMqttController extends GetxController {
         onSubscribed: _onSubscribed,
         onUnsubscribed: _onUnSubscribed,
         pongCallback: _pong,
+        onAutoReconnect: _onAutoReconnectStarted,
+        onAutoReconnected: _onAutoReconnectCompleted,
       ),
       autoSubscribe: true,
       topics: List<String>.from(_topics),
@@ -262,6 +264,16 @@ class IsmLiveMqttController extends GetxController {
           await _runMqttInitialize();
         } catch (e, st) {
           IsmLiveLog.error('MQTT initialize failed: $e', st);
+          IsmLiveDelegate.trackEvent(
+            IsmLiveAnalyticsEvent.mqttInitializeFailure,
+            properties: [
+              {
+                ..._mqttAnalyticsContext(),
+                'error': e.toString(),
+                'phase': 'setup_re_init',
+              }
+            ],
+          );
           _setDisconnectedImmediate();
         }
       }
@@ -303,6 +315,16 @@ class IsmLiveMqttController extends GetxController {
       await _runMqttInitialize();
     } catch (e, st) {
       IsmLiveLog.error('MQTT initialize failed: $e', st);
+      IsmLiveDelegate.trackEvent(
+        IsmLiveAnalyticsEvent.mqttInitializeFailure,
+        properties: [
+          {
+            ..._mqttAnalyticsContext(),
+            'error': e.toString(),
+            'phase': 'setup_first_init',
+          }
+        ],
+      );
       _mqttInitialized = false;
       _setDisconnectedImmediate();
     }
@@ -314,9 +336,35 @@ class IsmLiveMqttController extends GetxController {
         IsmLiveLog.error('subscribeStream called before setup()');
         return;
       }
-      if (!IsmLiveApp.isMqttConnected && !_manualReconnectInFlight) {
+      final helperConnected = _mqttHelper.isConnected;
+      IsmLiveDelegate.trackEvent(
+        IsmLiveAnalyticsEvent.mqttSubscribeStream,
+        properties: [
+          {
+            ..._mqttAnalyticsContext(),
+            'stream_id': streamId,
+            'helper_connected': helperConnected,
+            'ui_connected': IsmLiveApp.isMqttConnected,
+            'manual_reconnect_in_flight': _manualReconnectInFlight,
+          }
+        ],
+      );
+      // Use the actual broker connection state instead of the debounced UI
+      // flag (`IsmLiveApp.isMqttConnected`). The debounce delay can hide a
+      // disconnect that occurred < 3s ago, causing us to skip reconnect while
+      // the broker link is actually down.
+      if (!helperConnected && !_manualReconnectInFlight) {
         IsmLiveLog.info(
           'MQTT not connected; starting full re-init in background',
+        );
+        IsmLiveDelegate.trackEvent(
+          IsmLiveAnalyticsEvent.mqttSubscribeStreamNotConnected,
+          properties: [
+            {
+              ..._mqttAnalyticsContext(),
+              'stream_id': streamId,
+            }
+          ],
         );
         unawaited(reconnect());
       }
@@ -329,6 +377,16 @@ class IsmLiveMqttController extends GetxController {
       }
     } catch (e) {
       IsmLiveLog.error('Subscribe Error - $e');
+      IsmLiveDelegate.trackEvent(
+        IsmLiveAnalyticsEvent.mqttSubscribeStreamFailure,
+        properties: [
+          {
+            ..._mqttAnalyticsContext(),
+            'stream_id': streamId,
+            'error': e.toString(),
+          }
+        ],
+      );
     }
   }
 
@@ -396,12 +454,96 @@ class IsmLiveMqttController extends GetxController {
 
   void _onSubscribeFailed(String topic) {
     IsmLiveLog.error('MQTT Subscription failed - $topic');
+    IsmLiveDelegate.trackEvent(
+      IsmLiveAnalyticsEvent.mqttSubscriptionFailed,
+      properties: [
+        {
+          ..._mqttAnalyticsContext(),
+          'topic': topic,
+          'helper_connected': _mqttHelper.isConnected,
+        }
+      ],
+    );
   }
 
   void _onConnected() {
     _publishMqttConnectivityToApp(true);
     IsmLiveLog.success('MQTT connected');
     _trackMqttConnected();
+
+    // After any reconnect (auto or manual), verify stream-specific topics are
+    // still subscribed. The broker-level `resubscribeOnAutoReconnect` handles
+    // topics known to the mqtt_client at disconnect time, but a stream topic
+    // added via `subscribeStream()` during a brief disconnect window may have
+    // been enqueued (pending) and then lost if the client was replaced. This
+    // ensures the current stream always receives events.
+    _ensureStreamTopicsSubscribed();
+  }
+
+  void _ensureStreamTopicsSubscribed() {
+    if (!_mqttInitialized || _topics.isEmpty) return;
+    IsmLiveDelegate.trackEvent(
+      IsmLiveAnalyticsEvent.mqttTopicsResubscribed,
+      properties: [
+        {
+          ..._mqttAnalyticsContext(),
+          'topic_count': _topics.length,
+        }
+      ],
+    );
+    for (final topic in _topics) {
+      try {
+        _mqttHelper.subscribeTopic(topic);
+      } catch (e) {
+        IsmLiveLog.error('Re-subscribe topic "$topic" failed: $e');
+        IsmLiveDelegate.trackEvent(
+          IsmLiveAnalyticsEvent.mqttSubscriptionFailed,
+          properties: [
+            {
+              ..._mqttAnalyticsContext(),
+              'topic': topic,
+              'error': e.toString(),
+              'phase': 'resubscribe_on_connect',
+            }
+          ],
+        );
+      }
+    }
+  }
+
+  void _onAutoReconnectStarted() {
+    IsmLiveDelegate.trackEvent(
+      IsmLiveAnalyticsEvent.mqttAutoReconnectStarted,
+      properties: [
+        {
+          ..._mqttAnalyticsContext(),
+        }
+      ],
+    );
+  }
+
+  void _onAutoReconnectCompleted({required bool updatesReattached}) {
+    IsmLiveDelegate.trackEvent(
+      IsmLiveAnalyticsEvent.mqttAutoReconnectSuccess,
+      properties: [
+        {
+          ..._mqttAnalyticsContext(),
+          'updates_reattached': updatesReattached,
+          'helper_connected': _mqttHelper.isConnected,
+        }
+      ],
+    );
+    if (!updatesReattached) {
+      IsmLiveDelegate.trackEvent(
+        IsmLiveAnalyticsEvent.mqttAutoReconnectUpdatesSub,
+        properties: [
+          {
+            ..._mqttAnalyticsContext(),
+            'warning': 'updates_sub_not_reattached_after_auto_reconnect',
+          }
+        ],
+      );
+    }
   }
 
   /// After app resume, nudge broker auto-reconnect when the client is already
@@ -426,12 +568,41 @@ class IsmLiveMqttController extends GetxController {
     }
 
     _manualReconnectInFlight = true;
+    IsmLiveDelegate.trackEvent(
+      IsmLiveAnalyticsEvent.mqttManualReconnectAttempt,
+      properties: [
+        {
+          ..._mqttAnalyticsContext(),
+          'helper_connected': _mqttHelper.isConnected,
+        }
+      ],
+    );
     try {
       IsmLiveLog.info('MQTT manual re-init requested');
       await _runMqttInitialize();
-      return IsmLiveApp.isMqttConnected;
+      final connected = IsmLiveApp.isMqttConnected;
+      IsmLiveDelegate.trackEvent(
+        IsmLiveAnalyticsEvent.mqttManualReconnectSuccess,
+        properties: [
+          {
+            ..._mqttAnalyticsContext(),
+            'helper_connected': _mqttHelper.isConnected,
+            'ui_connected': connected,
+          }
+        ],
+      );
+      return connected;
     } catch (e, st) {
       IsmLiveLog.error('MQTT re-init failed: $e', st);
+      IsmLiveDelegate.trackEvent(
+        IsmLiveAnalyticsEvent.mqttManualReconnectFailure,
+        properties: [
+          {
+            ..._mqttAnalyticsContext(),
+            'error': e.toString(),
+          }
+        ],
+      );
       _mqttInitialized = false;
       _setDisconnectedImmediate();
       return false;

--- a/lib/src/controllers/mqtt/wrapper/core/callback_handler.dart
+++ b/lib/src/controllers/mqtt/wrapper/core/callback_handler.dart
@@ -22,6 +22,14 @@ class MqttCallbacks {
   /// A callback function that is called when a PING response is received from the MQTT broker.
   final PongCallback? pongCallback;
 
+  /// Called when the MQTT client starts auto-reconnect (connection lost).
+  final void Function()? onAutoReconnect;
+
+  /// Called when the MQTT client successfully completes auto-reconnect.
+  /// [updatesReattached] indicates whether the inbound message listener was
+  /// successfully re-created.
+  final void Function({required bool updatesReattached})? onAutoReconnected;
+
   /// Creates a new instance of `MqttCallbacks` with the provided callback functions.
   MqttCallbacks({
     this.onDisconnected,
@@ -30,5 +38,7 @@ class MqttCallbacks {
     this.onSubscribed,
     this.onUnsubscribed,
     this.pongCallback,
+    this.onAutoReconnect,
+    this.onAutoReconnected,
   });
 }

--- a/lib/src/controllers/mqtt/wrapper/core/helper.dart
+++ b/lib/src/controllers/mqtt/wrapper/core/helper.dart
@@ -498,16 +498,57 @@ class MqttHelper {
     _notifySessionLost(
       'MQTT connection lost — auto-reconnect started (network/broker unreachable)',
     );
+    _callbacks?.onAutoReconnect?.call();
   }
 
   /// Called after the broker connection is restored by the client's auto-reconnect.
   ///
   /// Subscriptions are re-established by [MqttClient.resubscribeOnAutoReconnect]
   /// when [MqttConfig.autoReconnect] is true; do not call [disconnect] here.
+  ///
+  /// Re-attaches the updates listener and notifies connection-stream subscribers
+  /// so the app resumes processing inbound messages (the listener was cancelled
+  /// in [_onAutoReconnect] → [_notifySessionLost]).
   void _onAutoReconnected() {
     _debugLog(
       'MQTT auto-reconnect completed — broker up, resubscribe handled by client',
     );
+
+    // Re-attach the inbound message listener that was cancelled during
+    // _onAutoReconnect. Without this, the MQTT client receives messages but
+    // the app never processes them (green indicator, no messages).
+    _updatesSub?.cancel();
+    final updates = _client?.updates;
+    if (updates != null) {
+      _updatesSub = updates.listen(
+        (List<MqttReceivedMessage<MqttMessage>> c) async {
+          _rawEventStream.add(c);
+          if (c.isEmpty) return;
+          final recMess = c.first.payload as MqttPublishMessage;
+          final topic = c.first.topic;
+
+          var payload = jsonDecode(
+            MqttPublishPayload.bytesToStringAsString(recMess.payload.message),
+          ) as Map<String, dynamic>;
+
+          _eventStream.add(
+            EventModel(
+              topic: topic,
+              payload: payload,
+            ),
+          );
+        },
+      );
+    }
+
+    final updatesReattached = _updatesSub != null;
+
+    if (!_connectionStream.isClosed) {
+      _connectionStream.add(true);
+    }
+    _callbacks?.onConnected?.call();
+    _callbacks?.onAutoReconnected?.call(updatesReattached: updatesReattached);
+
     // In case app requested new topics while reconnecting, flush them now.
     _flushPendingSubscriptions();
   }

--- a/lib/src/live_delegate.dart
+++ b/lib/src/live_delegate.dart
@@ -880,6 +880,30 @@ class IsmLiveAnalyticsEvent {
   // MQTT connectivity
   static const String mqttConnected = 'ism_live_mqtt_connected';
   static const String mqttDisconnected = 'ism_live_mqtt_disconnected';
+  static const String mqttAutoReconnectStarted =
+      'ism_live_mqtt_auto_reconnect_started';
+  static const String mqttAutoReconnectSuccess =
+      'ism_live_mqtt_auto_reconnect_success';
+  static const String mqttAutoReconnectUpdatesSub =
+      'ism_live_mqtt_auto_reconnect_updates_sub';
+  static const String mqttManualReconnectAttempt =
+      'ism_live_mqtt_manual_reconnect_attempt';
+  static const String mqttManualReconnectSuccess =
+      'ism_live_mqtt_manual_reconnect_success';
+  static const String mqttManualReconnectFailure =
+      'ism_live_mqtt_manual_reconnect_failure';
+  static const String mqttInitializeFailure =
+      'ism_live_mqtt_initialize_failure';
+  static const String mqttSubscribeStream =
+      'ism_live_mqtt_subscribe_stream';
+  static const String mqttSubscribeStreamNotConnected =
+      'ism_live_mqtt_subscribe_stream_not_connected';
+  static const String mqttSubscribeStreamFailure =
+      'ism_live_mqtt_subscribe_stream_failure';
+  static const String mqttSubscriptionFailed =
+      'ism_live_mqtt_subscription_failed';
+  static const String mqttTopicsResubscribed =
+      'ism_live_mqtt_topics_resubscribed';
 
   // Navigation / screen transitions
   static const String screenView = 'ism_live_screen_view';
@@ -919,6 +943,10 @@ class IsmLiveAnalyticsEvent {
     joinStreamMissingHostToken,
     preconnectAbortedStreamDisposed,
     roomConnectDiscardedStale,
+    mqttManualReconnectFailure,
+    mqttInitializeFailure,
+    mqttSubscribeStreamFailure,
+    mqttSubscriptionFailed,
   };
 
   /// Track only failure/error analytics (plus failed API calls via [apiResult]).
@@ -1010,6 +1038,18 @@ class IsmLiveAnalyticsEvent {
     // MQTT
     mqttConnected,
     mqttDisconnected,
+    mqttAutoReconnectStarted,
+    mqttAutoReconnectSuccess,
+    mqttAutoReconnectUpdatesSub,
+    mqttManualReconnectAttempt,
+    mqttManualReconnectSuccess,
+    mqttManualReconnectFailure,
+    mqttInitializeFailure,
+    mqttSubscribeStream,
+    mqttSubscribeStreamNotConnected,
+    mqttSubscribeStreamFailure,
+    mqttSubscriptionFailed,
+    mqttTopicsResubscribed,
 
     // Navigation
     screenView,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request enhances the MQTT connection management and analytics within the application. It introduces detailed event tracking for auto-reconnect processes, including start and success events, as well as failure scenarios during initialization, subscription, and manual reconnection attempts. Additionally, it ensures that after an auto-reconnect, stream-specific topics are re-subscribed to maintain message flow, and it provides callbacks to notify the app when auto-reconnect starts and completes, including whether inbound message listeners are reattached. These changes improve the robustness of MQTT connectivity handling and provide richer telemetry for monitoring connection stability and recovery behaviors.
<!-- kody-pr-summary:end -->