### PR TITLE
Fix: Manage sync viewer count, when mqtt disconnect and connect again

### DIFF
--- a/lib/src/controllers/mqtt/mqtt_controller.dart
+++ b/lib/src/controllers/mqtt/mqtt_controller.dart
@@ -478,6 +478,36 @@ class IsmLiveMqttController extends GetxController {
     // been enqueued (pending) and then lost if the client was replaced. This
     // ensures the current stream always receives events.
     _ensureStreamTopicsSubscribed();
+
+    // Recover any missed viewer-count deltas that happened while MQTT was down.
+    unawaited(_refreshViewerCountAfterReconnect());
+  }
+
+  Future<void> _refreshViewerCountAfterReconnect() async {
+    final streamId = _streamController.streamId;
+    if (streamId == null || streamId.isEmpty) {
+      return;
+    }
+
+    try {
+      final latestCount = await _streamController.viewModel.getStreamViewerCount(
+        streamId: streamId,
+      );
+      if (latestCount == null) {
+        return;
+      }
+
+      // Avoid stale update if user switched stream while request was in-flight.
+      if (_streamController.streamId != streamId) {
+        return;
+      }
+      _streamController.liveStreamViewersCount.value = latestCount;
+    } catch (e, st) {
+      IsmLiveLog.error(
+        'Failed to refresh viewer count after MQTT reconnect: $e',
+        st,
+      );
+    }
   }
 
   void _ensureStreamTopicsSubscribed() {

--- a/lib/src/view_models/stream_view_model.dart
+++ b/lib/src/view_models/stream_view_model.dart
@@ -267,6 +267,57 @@ class IsmLiveStreamViewModel {
     }
   }
 
+  /// Fetches the latest aggregate viewer count for a stream.
+  ///
+  /// Uses the viewer listing endpoint with minimal payload and supports
+  /// multiple backend key variants to stay backward compatible.
+  Future<int?> getStreamViewerCount({
+    required String streamId,
+  }) async {
+    try {
+      final res = await _repository.getStreamViewer(
+        streamId: streamId,
+        limit: 1,
+        skip: 0,
+      );
+      if (res.hasError) {
+        return null;
+      }
+
+      final decoded = jsonDecode(res.data);
+      if (decoded is! Map<String, dynamic>) {
+        return null;
+      }
+
+      int? toInt(dynamic value) {
+        if (value == null) return null;
+        if (value is int) return value;
+        if (value is num) return value.toInt();
+        if (value is String) return int.tryParse(value);
+        return null;
+      }
+
+      final count = toInt(decoded['viewersCount']) ??
+          toInt(decoded['viewerCount']) ??
+          toInt(decoded['count']) ??
+          toInt(decoded['totalCount']) ??
+          toInt(decoded['totalViewers']);
+
+      if (count != null) {
+        return count;
+      }
+
+      final viewers = decoded['viewers'];
+      if (viewers is List) {
+        return viewers.length;
+      }
+      return null;
+    } catch (e, st) {
+      IsmLiveLog.error(e, st);
+      return null;
+    }
+  }
+
   // / get Api for Presigned Url.....
   Future<IsmLiveResponseModel> updatePresignedUrl({
     required bool showLoading,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request addresses the issue of accurately maintaining the viewer count in the live stream when the MQTT connection is interrupted and subsequently re-established. It implements a mechanism to recover and update the viewer count by fetching the latest data from the backend after reconnecting to MQTT. This ensures that the displayed viewer count remains consistent and up-to-date, even if viewer updates were missed during the disconnection.
<!-- kody-pr-summary:end -->