### PR TITLE
Main improment

### DIFF
--- a/lib/src/controllers/mqtt/mqtt_controller.dart
+++ b/lib/src/controllers/mqtt/mqtt_controller.dart
@@ -478,6 +478,36 @@ class IsmLiveMqttController extends GetxController {
     // been enqueued (pending) and then lost if the client was replaced. This
     // ensures the current stream always receives events.
     _ensureStreamTopicsSubscribed();
+
+    // Recover any missed viewer-count deltas that happened while MQTT was down.
+    unawaited(_refreshViewerCountAfterReconnect());
+  }
+
+  Future<void> _refreshViewerCountAfterReconnect() async {
+    final streamId = _streamController.streamId;
+    if (streamId == null || streamId.isEmpty) {
+      return;
+    }
+
+    try {
+      final latestCount = await _streamController.viewModel.getStreamViewerCount(
+        streamId: streamId,
+      );
+      if (latestCount == null) {
+        return;
+      }
+
+      // Avoid stale update if user switched stream while request was in-flight.
+      if (_streamController.streamId != streamId) {
+        return;
+      }
+      _streamController.liveStreamViewersCount.value = latestCount;
+    } catch (e, st) {
+      IsmLiveLog.error(
+        'Failed to refresh viewer count after MQTT reconnect: $e',
+        st,
+      );
+    }
   }
 
   void _ensureStreamTopicsSubscribed() {

--- a/lib/src/controllers/mqtt/wrapper/models/mqtt_config.dart
+++ b/lib/src/controllers/mqtt/wrapper/models/mqtt_config.dart
@@ -44,8 +44,8 @@ class MqttConfig {
     this.secure = false,
     this.autoReconnect = true,
     this.maxAutoReconnectRetry = 3,
-    this.keepAliveSeconds = 60,
-    this.disconnectOnNoPingResponseSeconds = 30,
+    this.keepAliveSeconds = 30,
+    this.disconnectOnNoPingResponseSeconds = 10,
   });
 
   /// Creates a copy of the current `MqttConfig` instance with optional changes.
@@ -108,9 +108,9 @@ class MqttConfig {
       secure: map['secure'] as bool,
       autoReconnect: map['autoReconnect'] as bool,
       maxAutoReconnectRetry: map['maxAutoReconnectRetry'] as int,
-      keepAliveSeconds: map['keepAliveSeconds'] as int? ?? 60,
+      keepAliveSeconds: map['keepAliveSeconds'] as int? ?? 30,
       disconnectOnNoPingResponseSeconds:
-          map['disconnectOnNoPingResponseSeconds'] as int? ?? 30,
+          map['disconnectOnNoPingResponseSeconds'] as int? ?? 10,
     );
   }
 

--- a/lib/src/view_models/stream_view_model.dart
+++ b/lib/src/view_models/stream_view_model.dart
@@ -267,6 +267,57 @@ class IsmLiveStreamViewModel {
     }
   }
 
+  /// Fetches the latest aggregate viewer count for a stream.
+  ///
+  /// Uses the viewer listing endpoint with minimal payload and supports
+  /// multiple backend key variants to stay backward compatible.
+  Future<int?> getStreamViewerCount({
+    required String streamId,
+  }) async {
+    try {
+      final res = await _repository.getStreamViewer(
+        streamId: streamId,
+        limit: 1,
+        skip: 0,
+      );
+      if (res.hasError) {
+        return null;
+      }
+
+      final decoded = jsonDecode(res.data);
+      if (decoded is! Map<String, dynamic>) {
+        return null;
+      }
+
+      int? toInt(dynamic value) {
+        if (value == null) return null;
+        if (value is int) return value;
+        if (value is num) return value.toInt();
+        if (value is String) return int.tryParse(value);
+        return null;
+      }
+
+      final count = toInt(decoded['viewersCount']) ??
+          toInt(decoded['viewerCount']) ??
+          toInt(decoded['count']) ??
+          toInt(decoded['totalCount']) ??
+          toInt(decoded['totalViewers']);
+
+      if (count != null) {
+        return count;
+      }
+
+      final viewers = decoded['viewers'];
+      if (viewers is List) {
+        return viewers.length;
+      }
+      return null;
+    } catch (e, st) {
+      IsmLiveLog.error(e, st);
+      return null;
+    }
+  }
+
   // / get Api for Presigned Url.....
   Future<IsmLiveResponseModel> updatePresignedUrl({
     required bool showLoading,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request enhances the MQTT controller to recover and update viewer count information after reconnecting, ensuring more accurate real-time viewer metrics. It introduces a method to fetch the latest viewer count from the backend upon MQTT reconnection, updating the stream's viewer count display accordingly. Additionally, it refines the MQTT configuration by reducing keep-alive and disconnect timeout intervals for improved connection responsiveness. A new method is also added to the stream view model to retrieve the current aggregate viewer count via the backend, supporting backward compatibility with multiple response formats. Overall, these changes improve the reliability and accuracy of viewer metrics in the live stream application.
<!-- kody-pr-summary:end -->