### PR TITLE
In app purchase pass token

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -100,10 +100,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -738,18 +738,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: "direct overridden"
     description:
@@ -1191,10 +1191,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.9"
   timezone:
     dependency: transitive
     description:

--- a/lib/src/controllers/coins_plans_wallet_controller/coins_plans_wallet_controller.dart
+++ b/lib/src/controllers/coins_plans_wallet_controller/coins_plans_wallet_controller.dart
@@ -148,10 +148,18 @@ class CoinsPlansWalletController extends GetxController
     required ProductDetails storePlan,
     required CoinPlan apiPlan,
   }) async {
-    final userId = Get.find<IsmLiveStreamController>().user?.userId ?? '';
+    // final userId = Get.find<IsmLiveStreamController>().user?.userId ?? '';
+    final accountPurchasetoken =
+        await _coinsPlansWalletViewMode.getAccountPurchaseToken();
+
+    // If token fetch failed (iOS), show error popup and stop the flow.
+    if (accountPurchasetoken == null || accountPurchasetoken.isEmpty) {
+      return;
+    }
+
     final purchaseParam = PurchaseParam(
       productDetails: storePlan,
-      applicationUserName: userId,
+      applicationUserName: accountPurchasetoken,
     );
     InAppManager.i.buyConsumable(
       purchaseParam: purchaseParam,

--- a/lib/src/controllers/coins_plans_wallet_controller/coins_plans_wallet_controller.dart
+++ b/lib/src/controllers/coins_plans_wallet_controller/coins_plans_wallet_controller.dart
@@ -163,11 +163,18 @@ class CoinsPlansWalletController extends GetxController
     );
     InAppManager.i.buyConsumable(
       purchaseParam: purchaseParam,
-      onPurchase: (purchaseDetails) => purchasePlan(
-        purchaseDetails: purchaseDetails,
-        apiPlan: apiPlan,
-        storePlan: storePlan,
-      ),
+      onPurchase: (purchaseDetails) async {
+        // No backend `tokenPurchase` call from here (per requirement).
+        // Still complete the platform purchase to avoid leaving it pending.
+        try {
+          await InAppPurchase.instance.completePurchase(purchaseDetails);
+        } catch (_) {
+          debugPrint('Complete Purchase Error :- $_');
+        }
+
+        unawaited(totalWalletCoins('coin'));
+        unawaited(totalWalletCoins('usd'));
+      },
     );
   }
 

--- a/lib/src/data/remote/apis.dart
+++ b/lib/src/data/remote/apis.dart
@@ -5,7 +5,6 @@ class IsmLiveApis {
   const IsmLiveApis._();
 
   static const String baseUrl = 'https://apis.isometrik.ai';
-  static const String adminBaseUrl = 'https://admin-apis.isometrik.io';
   static const String _productionBaseUrl = 'https://apinew.isometrik.ai';
   static const String _devBaseUrl = 'https://service-apis.isometrik.io';
 

--- a/lib/src/data/remote/apis.dart
+++ b/lib/src/data/remote/apis.dart
@@ -5,6 +5,7 @@ class IsmLiveApis {
   const IsmLiveApis._();
 
   static const String baseUrl = 'https://apis.isometrik.ai';
+  static const String adminBaseUrl = 'https://admin-apis.isometrik.io';
   static const String _productionBaseUrl = 'https://apinew.isometrik.ai';
   static const String _devBaseUrl = 'https://service-apis.isometrik.io';
 
@@ -57,6 +58,7 @@ class IsmLiveApis {
   static const String sendGiftToStreamer = '/live/v1/giftTransfer';
   static const String getCurrencyPlans = '/v1/currencyPlan/isometrikAuth';
   static const String purchaseCoinsPlans = '/v1/appWallet/tokenPurchase';
+  static const String applePurchaseToken = '/v1/appWallet/applePurchaseToken';
 
   // Streams
   static const String _streaming = '/streaming/v2';

--- a/lib/src/repositories/coins_plans_wallet_repository.dart
+++ b/lib/src/repositories/coins_plans_wallet_repository.dart
@@ -43,7 +43,7 @@ class CoinsPlansWalletRepository {
   }) async =>
       await _apiWrapper.makeRequest(
         IsmLiveApis.applePurchaseToken,
-        baseUrl: IsmLiveApis.adminBaseUrl,
+        baseUrl: IsmLiveApis.baseUrlAsPerMode,
         type: IsmLiveRequestType.get,
         headers: IsmLiveUtility.tokenHeader(),
         showLoader: showLoader,

--- a/lib/src/repositories/coins_plans_wallet_repository.dart
+++ b/lib/src/repositories/coins_plans_wallet_repository.dart
@@ -18,8 +18,9 @@ class CoinsPlansWalletRepository {
       );
 
   ///  for request to purchase the coins plans ...
-  Future<IsmLiveResponseModel> purchaseCoinsPlans(
-          {required Map<String, dynamic> data, required}) async =>
+  Future<IsmLiveResponseModel> purchaseCoinsPlans({
+    required Map<String, dynamic> data,
+  }) async =>
       await _apiWrapper.makeRequest(
         IsmLiveApis.purchaseCoinsPlans,
         baseUrl: IsmLiveApis.baseUrlAsPerMode,
@@ -27,6 +28,26 @@ class CoinsPlansWalletRepository {
         headers: IsmLiveUtility.tokenHeader(),
         payload: data,
         showLoader: true,
+      );
+
+  /// Fetches an iOS `appAccountToken` for StoreKit purchases.
+  ///
+  /// Backend returns:
+  /// {
+  ///   "status": "...",
+  ///   "message": "Success",
+  ///   "data": { "appAccountToken": "<uuid>" }
+  /// }
+  Future<IsmLiveResponseModel> getAccountPurchaseToken({
+    bool showLoader = true,
+  }) async =>
+      await _apiWrapper.makeRequest(
+        IsmLiveApis.applePurchaseToken,
+        baseUrl: IsmLiveApis.adminBaseUrl,
+        type: IsmLiveRequestType.get,
+        headers: IsmLiveUtility.tokenHeader(),
+        showLoader: showLoader,
+        showDialog: false,
       );
 
   Future<IsmLiveResponseModel> totalWalletCoins(String currency) {

--- a/lib/src/view_models/coins_plans_wallet_view_mode.dart
+++ b/lib/src/view_models/coins_plans_wallet_view_mode.dart
@@ -38,6 +38,41 @@ class CoinsPlansWalletViewMode {
     return null;
   }
 
+  /// iOS-only helper: get `appAccountToken` required by your backend.
+  ///
+  /// If the API fails, this shows an error popup and returns null.
+  Future<String?> getAccountPurchaseToken({
+    bool showLoader = true,
+  }) async {
+    try {
+      final res = await _coinsPlansWalletRepository.getAccountPurchaseToken(
+        showLoader: showLoader,
+      );
+      if (res.hasError) {
+        await IsmLiveUtility.showInfoDialog(res);
+        return null;
+      }
+
+      final decoded = jsonDecode(res.data) as Map<String, dynamic>;
+      final data = decoded['data'];
+      if (data is Map<String, dynamic>) {
+        final token = data['appAccountToken']?.toString().trim();
+        if (token != null && token.isNotEmpty) return token;
+      }
+
+      IsmLiveUtility.showAlertDialog(
+        message: 'Unable to fetch Account token. Please try again.',
+      );
+      return null;
+    } catch (e, st) {
+      IsmLiveLog.error(e, st);
+      IsmLiveUtility.showAlertDialog(
+        message: 'Unable to fetch Account token. Please try again.',
+      );
+      return null;
+    }
+  }
+
   Future<IsmLiveCoinBalanceModel?> totalWalletCoins(String currency) async {
     try {
       var res = await _coinsPlansWalletRepository.totalWalletCoins(currency);


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new mechanism for obtaining an iOS-specific purchase token required for store transactions. It modifies the in-app purchase flow to fetch an `appAccountToken` from the backend before initiating a consumable purchase, ensuring the token is available and valid. If the token retrieval fails, the purchase process is halted, and an error is shown to the user. Additionally, a new API endpoint is added to support fetching this token from the backend. These changes facilitate a more secure and reliable purchase process on iOS by integrating backend-provided tokens into the in-app purchase flow.
<!-- kody-pr-summary:end -->