### PR TITLE
fix: update transaction on purchase, update coins as soon as purchase…

### DIFF
--- a/lib/src/controllers/coins_plans_wallet_controller/coins_plans_wallet_controller.dart
+++ b/lib/src/controllers/coins_plans_wallet_controller/coins_plans_wallet_controller.dart
@@ -172,8 +172,8 @@ class CoinsPlansWalletController extends GetxController
           debugPrint('Complete Purchase Error :- $_');
         }
 
-        unawaited(totalWalletCoins('coin'));
-        unawaited(totalWalletCoins('usd'));
+        await totalWalletCoins('coin');
+        await totalWalletCoins('usd');
       },
     );
   }

--- a/lib/src/views/coins_plans_wallet_view/coin_transactions_view.dart
+++ b/lib/src/views/coins_plans_wallet_view/coin_transactions_view.dart
@@ -57,10 +57,12 @@ class IsmLiveCoinTransactions extends StatelessWidget {
               onTap: (index) {
                 controller.coinTransactionType =
                     IsmLiveCoinTransactionType.values[index];
-
-                if (controller.transactions.isEmpty) {
-                  controller.fetchTransactions();
-                }
+                // Always refresh the selected tab so the latest transactions
+                // (e.g. newly purchased credits) appear even if the list already
+                // had older items.
+                controller.fetchTransactions(
+                  type: controller.coinTransactionType,
+                );
               },
               tabs: [
                 ...IsmLiveCoinTransactionType.values.map(


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the transaction handling logic to ensure that wallet coin totals are accurately refreshed after a purchase by awaiting the total calculation functions, and modifies the transaction view to always refresh transaction data when switching tabs, ensuring the latest transactions are displayed even if previous data exists.
<!-- kody-pr-summary:end -->