### PR TITLE
Fix: Double EndStream screen opening

### DIFF
--- a/lib/src/controllers/mqtt/mqtt_controller.dart
+++ b/lib/src/controllers/mqtt/mqtt_controller.dart
@@ -1120,6 +1120,7 @@ class IsmLiveMqttController extends GetxController {
             _streamController.closeStreamView(false, fromMqtt: true);
           } else {
             if (streamId == _streamController.streamId) {
+              await Future.delayed(const Duration(milliseconds: 300));
               _disconnectRoom();
               _streamController.closeStreamView(true,
                   streamId: streamId, fromMqtt: true);

--- a/lib/src/views/stream/views/end_stream_view.dart
+++ b/lib/src/views/stream/views/end_stream_view.dart
@@ -51,6 +51,7 @@ class IsmLiveEndStream extends StatelessWidget {
                               controller.user?.userProfileImageUrl ??
                               '',
                           name: controller.user?.userName ?? 'U',
+                          initials: controller.user?.profileInitials,
                           height: IsmLiveDimens.ninty,
                           width: IsmLiveDimens.ninty,
                           isProfileImage: true,

--- a/lib/src/views/stream/widgets/stream_card.dart
+++ b/lib/src/views/stream/widgets/stream_card.dart
@@ -72,8 +72,10 @@ class IsmLiveStreamCard extends StatelessWidget {
                                   ? stream.scheduleStartTime!.formattedDate
                                   : IsmLiveStrings.tvContinue,
                               style: context.textTheme.labelSmall?.copyWith(
-                                color: Theme.of(context).brightness == Brightness.dark
-                                    ? context.liveTheme?.primaryButtonTheme?.foregroundColor ??
+                                color: Theme.of(context).brightness ==
+                                        Brightness.dark
+                                    ? context.liveTheme?.primaryButtonTheme
+                                            ?.foregroundColor ??
                                         IsmLiveColors.black
                                     : context.liveTheme?.selectedTextColor ??
                                         IsmLiveColors.white,
@@ -92,7 +94,7 @@ class IsmLiveStreamCard extends StatelessWidget {
                       children: [
                         IsmLiveImage.network(
                           stream.userDetails?.userProfile ?? '',
-                          name: stream.userDetails?.userName ?? 'U',
+                          name: stream.userDetails?.name ?? 'U',
                           dimensions: IsmLiveDimens.thirtyTwo,
                           isProfileImage: true,
                         ),


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request addresses an issue where the EndStream screen was opening multiple times unexpectedly. The main change introduces a slight delay (300 milliseconds) before disconnecting the room when a specific MQTT message is received, helping to prevent rapid or duplicate screen openings. Additionally, minor UI improvements were made, such as passing user profile initials to the EndStream view and ensuring consistent user name references in stream cards. Overall, these modifications enhance the stability and user experience by preventing duplicate EndStream screens and improving UI data handling.
<!-- kody-pr-summary:end -->