### PR TITLE
Main enhancement

### DIFF
--- a/lib/src/live_app.dart
+++ b/lib/src/live_app.dart
@@ -393,6 +393,32 @@ class IsmLiveApp extends StatefulWidget {
     }
   }
 
+  /// Fetches a paginated list of scheduled streams into stream listing state.
+  ///
+  /// This delegates to [IsmLiveStreamController.fetchScheduledStream] so host
+  /// apps can trigger the same scheduled listing flow used internally by SDK
+  /// screens.
+  static Future<void> fetchScheduledStream({
+    IsmLiveStreamType? type,
+    int skip = 0,
+  }) async {
+    assert(
+      _initialized,
+      'IsmLiveApp || IsmLiveMqtt is not initialized. Initialize it using `IsmLiveApp.initialize(config) and/or IsmLiveApp.initializeMqtt()`',
+    );
+
+    if (!Get.isRegistered<IsmLiveStreamController>()) {
+      IsmLiveStreamBinding().dependencies();
+    }
+
+    try {
+      final controller = Get.find<IsmLiveStreamController>();
+      await controller.fetchScheduledStream(type: type, skip: skip);
+    } catch (e, stack) {
+      IsmLiveLog.error('IsmLiveApp.fetchScheduledStream failed: $e\n$stack');
+    }
+  }
+
   static bool _initialized = false;
   static bool _initializing = false; // To prevent re-entrancy
   static bool _mqttInitialized = false;

--- a/lib/src/views/stream/widgets/chat.dart
+++ b/lib/src/views/stream/widgets/chat.dart
@@ -273,9 +273,9 @@ class _IsmLiveChatViewState extends State<IsmLiveChatView>
                       // Existing restriction for host messages:
                       // only privileged roles or members can act on host messages.
                       final openSheetByMessageSource = message.sentByHost
-                          ? (controller.isCopublisher ||
+                          ? (/*controller.isCopublisher ||*/
                               controller.isModerator ||
-                              controller.isMember ||
+                             /* controller.isMember ||*/
                               controller.isHost)
                           : true;
 

--- a/lib/src/views/stream/widgets/stream_header.dart
+++ b/lib/src/views/stream/widgets/stream_header.dart
@@ -152,8 +152,9 @@ class IsmLiveModeratorCount extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) => GetBuilder<IsmLiveStreamController>(
-        builder: (controller) => (controller.isMember ||
-                    (controller.isCopublisher) ||
+        builder: (controller) =>
+                    (/*controller.isMember ||
+                    (controller.isCopublisher) ||*/
                     (controller.isHost) ||
                     (controller.isModerator)) &&
                 !controller.isPk


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new static method in the `IsmLiveApp` class to fetch a paginated list of scheduled streams, enabling host applications to trigger the same scheduled stream listing flow used internally by the SDK. Additionally, it updates access control logic in chat and stream header widgets to relax restrictions on host messages and moderator counts, potentially allowing broader access or display of certain user roles within the live stream interface.
<!-- kody-pr-summary:end -->