### PR TITLE
Feat: Exposed 'fetchScheduledStream'

### DIFF
--- a/lib/src/live_app.dart
+++ b/lib/src/live_app.dart
@@ -399,7 +399,7 @@ class IsmLiveApp extends StatefulWidget {
   /// apps can trigger the same scheduled listing flow used internally by SDK
   /// screens.
   static Future<void> fetchScheduledStream({
-    IsmLiveStreamType? type,
+    IsmLiveStreamType type = IsmLiveStreamType.scheduledStreams,
     int skip = 0,
   }) async {
     assert(


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the `fetchScheduledStream` method in the `IsmLiveApp` class to set a default value for the `type` parameter. Specifically, it now defaults to `IsmLiveStreamType.scheduledStreams` if no value is provided. This change simplifies the method call by removing the need to explicitly specify the stream type when fetching scheduled streams, thereby improving ease of use and reducing potential errors.
<!-- kody-pr-summary:end -->