### PR TITLE
Main fix

### DIFF
--- a/example/lib/controllers/home/home_controller.dart
+++ b/example/lib/controllers/home/home_controller.dart
@@ -72,12 +72,13 @@ class HomeController extends GetxController {
     );
     // await IsmLiveApp.initialize(configData, navigatorKey: kNavigatorKey);
     IsmLiveApp.configureInterface(
-      useGridLayoutForMultipleParticipants : false,
+      useGridLayoutForMultipleParticipants : true,
       productionMode: true,
       // Remove `const` if you uncomment builders or callbacks below.
       goLiveScreenConfigure: const IsmLiveGoLiveScreenConfigure(
         isProductStreamFeatureEnabled: true,
         isScheduleStreamFeatureEnabled: true,
+        defaultBroadcastDescription: "Hey dubly!"
         // Feature flags:
         // isHdStreamFeatureEnabled: true,
         // isRtmpStreamFeatureEnabled: true,

--- a/example/lib/controllers/home/home_controller.dart
+++ b/example/lib/controllers/home/home_controller.dart
@@ -72,7 +72,7 @@ class HomeController extends GetxController {
     );
     // await IsmLiveApp.initialize(configData, navigatorKey: kNavigatorKey);
     IsmLiveApp.configureInterface(
-      useGridLayoutForMultipleParticipants : true,
+      useGridLayoutForMultipleParticipants : false,
       productionMode: true,
       // Remove `const` if you uncomment builders or callbacks below.
       goLiveScreenConfigure: const IsmLiveGoLiveScreenConfigure(

--- a/example/lib/controllers/home/home_controller.dart
+++ b/example/lib/controllers/home/home_controller.dart
@@ -73,6 +73,7 @@ class HomeController extends GetxController {
     // await IsmLiveApp.initialize(configData, navigatorKey: kNavigatorKey);
     IsmLiveApp.configureInterface(
       useGridLayoutForMultipleParticipants : false,
+      showParticipantFullNamesInPublisherGrid : true,
       productionMode: true,
       // Remove `const` if you uncomment builders or callbacks below.
       goLiveScreenConfigure: const IsmLiveGoLiveScreenConfigure(

--- a/lib/src/live_app.dart
+++ b/lib/src/live_app.dart
@@ -660,6 +660,10 @@ class IsmLiveApp extends StatefulWidget {
     /// When `true`, uses the multi-column grid layout.
     bool useGridLayoutForMultipleParticipants = false,
 
+    /// When `true`, 2+ publishers show each participant's full name at the
+    /// bottom-left of their tile in the publisher grid/stack. Default `false`.
+    bool showParticipantFullNamesInPublisherGrid = false,
+
     /// When `false`, [IsmLiveStreamController.getStreams] does not call the
     /// listing API. Default `true`.
     bool enableInternalStreamListingRefresh = true,
@@ -784,6 +788,8 @@ class IsmLiveApp extends StatefulWidget {
         enableInternalStreamListingRefresh;
     IsmLiveDelegate.useGridLayoutForMultipleParticipants =
         useGridLayoutForMultipleParticipants;
+    IsmLiveDelegate.showParticipantFullNamesInPublisherGrid =
+        showParticipantFullNamesInPublisherGrid;
   }
 
   static Future<void> endStream(
@@ -1014,6 +1020,10 @@ class IsmLiveApp extends StatefulWidget {
   /// See [IsmLiveDelegate.useGridLayoutForMultipleParticipants].
   static bool get useGridLayoutForMultipleParticipants =>
       IsmLiveDelegate.useGridLayoutForMultipleParticipants;
+
+  /// See [IsmLiveDelegate.showParticipantFullNamesInPublisherGrid].
+  static bool get showParticipantFullNamesInPublisherGrid =>
+      IsmLiveDelegate.showParticipantFullNamesInPublisherGrid;
 
   static Alignment get headerPosition => IsmLiveDelegate.headerPosition;
 

--- a/lib/src/live_delegate.dart
+++ b/lib/src/live_delegate.dart
@@ -1069,6 +1069,12 @@ class IsmLiveDelegate {
   /// Optional default value for Restream Broadcast toggle in Go Live.
   static bool? defaultRestreamBroadcast;
 
+  /// Optional default text for the stream description field in Go Live.
+  ///
+  /// Used when [IsmLiveGoLiveScreenConfigure.defaultBroadcastDescription] is
+  /// not set. Ignored for existing/scheduled streams (see go live view init).
+  static String? defaultBroadcastDescription;
+
   static bool? productStream;
 
   static bool? rtmpStream;
@@ -1385,6 +1391,7 @@ class IsmLiveGoLiveScreenConfigure {
     this.defaultHdBroadcastToggleValue,
     this.defaultRecordBroadcastToggleValue,
     this.defaultRestreamBroadcastToggleValue,
+    this.defaultBroadcastDescription,
     this.radioTileTextStyle,
     this.addCoverTextStyle,
     this.addIcon,
@@ -1460,6 +1467,11 @@ class IsmLiveGoLiveScreenConfigure {
   /// This is ignored while editing an existing/scheduled stream.
   final bool? defaultRestreamBroadcastToggleValue;
 
+  /// Optional default text for the stream description on a fresh GoLive flow.
+  ///
+  /// This is ignored while editing an existing/scheduled stream.
+  final String? defaultBroadcastDescription;
+
   /// Custom text style for radio tile components (switches, toggles).
   ///
   /// If provided, this function will be called to generate text styles for text elements
@@ -1520,6 +1532,7 @@ class IsmLiveGoLiveScreenConfigure {
     bool? defaultHdBroadcastToggleValue,
     bool? defaultRecordBroadcastToggleValue,
     bool? defaultRestreamBroadcastToggleValue,
+    String? defaultBroadcastDescription,
     TextStyle Function(BuildContext context, bool isDark)? radioTileTextStyle,
     TextStyle? addCoverTextStyle,
     IconData? addIcon,
@@ -1558,6 +1571,8 @@ class IsmLiveGoLiveScreenConfigure {
         defaultRestreamBroadcastToggleValue:
             defaultRestreamBroadcastToggleValue ??
                 this.defaultRestreamBroadcastToggleValue,
+        defaultBroadcastDescription: defaultBroadcastDescription ??
+            this.defaultBroadcastDescription,
         radioTileTextStyle: radioTileTextStyle ?? this.radioTileTextStyle,
         addCoverTextStyle: addCoverTextStyle ?? this.addCoverTextStyle,
         addIcon: addIcon ?? this.addIcon,

--- a/lib/src/live_delegate.dart
+++ b/lib/src/live_delegate.dart
@@ -1038,6 +1038,13 @@ class IsmLiveDelegate {
   /// `IsmLiveApp.configureInterface`.
   static bool useGridLayoutForMultipleParticipants = false;
 
+  /// When `true`, each tile in the multi-participant publisher area shows the
+  /// participant [IsmLiveMemberDetailsModel.fullName] (with LiveKit name as
+  /// fallback) on a semi-transparent strip at the bottom-left. Only applies
+  /// when two or more publishers are shown. Default `false`. Set via
+  /// `IsmLiveApp.configureInterface`.
+  static bool showParticipantFullNamesInPublisherGrid = false;
+
   static List<IsmLiveStreamOption> viewersOption = [];
 
   static List<IsmLiveStreamOption> hostOptions = [];

--- a/lib/src/views/stream/stream_view.dart
+++ b/lib/src/views/stream/stream_view.dart
@@ -478,6 +478,10 @@ class _IsmLiveStreamViewState extends State<_IsmLiveStreamView> {
           final mediaQuery = MediaQuery.of(context);
           final isKeyboardOpen = mediaQuery.viewInsets.bottom > 0;
           final systemBottomInset = mediaQuery.viewPadding.bottom;
+          final keyboardBottom = mediaQuery.viewInsets.bottom;
+          // When the IME is open, keep this sum on bottom-aligned overlays so they
+          // stay above the keyboard (body no longer resizes — see Scaffold flag).
+          final overlayBottomPadding = systemBottomInset + keyboardBottom;
           final isActiveStreamPage = controller.streamId == widget.streamId;
           return PopScope(
             canPop: false,
@@ -490,6 +494,9 @@ class _IsmLiveStreamViewState extends State<_IsmLiveStreamView> {
             },
             child: Scaffold(
               extendBodyBehindAppBar: true,
+              // Keep full viewport height so the video grid does not compress when
+              // the IME opens; chat/input use [keyboardBottom] padding instead.
+              resizeToAvoidBottomInset: false,
               backgroundColor: context.liveTheme?.streamBackgroundColor ??
                   IsmLiveColors.black,
               body: SafeArea(
@@ -498,6 +505,7 @@ class _IsmLiveStreamViewState extends State<_IsmLiveStreamView> {
                 child: Container(
                   color: Colors.black, // Ensures status bar area is always dark
                   child: Stack(
+                    clipBehavior: Clip.none,
                     children: [
                       const Positioned.fill(
                         child: ColoredBox(color: Colors.black),
@@ -538,8 +546,9 @@ class _IsmLiveStreamViewState extends State<_IsmLiveStreamView> {
                             child: const ColoredBox(color: Colors.transparent),
                           ),
                         ),
-                      if (isActiveStreamPage || (widget.isSchedule && !IsmLiveStreamId.isValid(
-                          widget.streamId)))
+                      if (isActiveStreamPage ||
+                          (widget.isSchedule &&
+                              !IsmLiveStreamId.isValid(widget.streamId)))
                         Positioned.fill(
                           child: IgnorePointer(
                             ignoring: !_overlaysVisible,
@@ -548,344 +557,353 @@ class _IsmLiveStreamViewState extends State<_IsmLiveStreamView> {
                               duration: const Duration(milliseconds: 200),
                               child: Stack(
                                 fit: StackFit.expand,
-                              children: [
-                                // Gradients positioned right after publisher grid to only overlay video content
-                                const _TopDarkGradient(),
-                                const _BottomDarkGradient(),
-                                Align(
-                                  alignment: IsmLiveApp.headerPosition,
-                                  child: Obx(
-                                    () {
-                                      final isActiveStreamPage =
-                                          controller.streamId ==
-                                              widget.streamId;
-                                      final hostDetails = isActiveStreamPage
-                                          ? controller.hostDetails
-                                          : null;
-                                      if (!((controller
-                                                      .room?.localParticipant !=
-                                                  null) &&
-                                              IsmLiveApp.showHeader) &&
-                                          !widget.isSchedule) {
-                                        return IsmLiveDimens.box0;
-                                      }
-                                      final defaultHeader = _StreamHeader(
-                                          streamId: widget.streamId);
-                                      return IsmLiveApp.streamHeader?.call(
-                                            context,
-                                            hostDetails,
-                                            controller
-                                                .descriptionController.text,
-                                            defaultHeader,
-                                          ) ??
-                                          defaultHeader;
-                                    },
+                                children: [
+                                  // Gradients positioned right after publisher grid to only overlay video content
+                                  const _TopDarkGradient(),
+                                  const _BottomDarkGradient(),
+                                  Align(
+                                    alignment: IsmLiveApp.headerPosition,
+                                    child: Obx(
+                                      () {
+                                        final isActiveStreamPage =
+                                            controller.streamId ==
+                                                widget.streamId;
+                                        final hostDetails = isActiveStreamPage
+                                            ? controller.hostDetails
+                                            : null;
+                                        if (!((controller.room
+                                                        ?.localParticipant !=
+                                                    null) &&
+                                                IsmLiveApp.showHeader) &&
+                                            !widget.isSchedule) {
+                                          return IsmLiveDimens.box0;
+                                        }
+                                        final defaultHeader = _StreamHeader(
+                                            streamId: widget.streamId);
+                                        return IsmLiveApp.streamHeader?.call(
+                                              context,
+                                              hostDetails,
+                                              controller
+                                                  .descriptionController.text,
+                                              defaultHeader,
+                                            ) ??
+                                            defaultHeader;
+                                      },
+                                    ),
                                   ),
-                                ),
-                                Obx(
-                                  () => (controller.room?.localParticipant !=
-                                          null)
-                                      ? SafeArea(
-                                          top: false,
-                                          child: Column(
-                                            crossAxisAlignment:
-                                                CrossAxisAlignment.start,
-                                            children: [
-                                              Expanded(
+                                  Obx(
+                                    () =>
+                                        (controller.room?.localParticipant !=
+                                                null)
+                                            ? SafeArea(
+                                                top: false,
                                                 child: Padding(
-                                                  padding: IsmLiveDimens
-                                                      .edgeInsets8_0,
-                                                  child: Row(
+                                                  padding: EdgeInsets.only(
+                                                    bottom: keyboardBottom,
+                                                  ),
+                                                  child: Column(
                                                     crossAxisAlignment:
-                                                        CrossAxisAlignment.end,
+                                                        CrossAxisAlignment
+                                                            .start,
                                                     children: [
                                                       Expanded(
-                                                        child: IsmLiveApp
-                                                                .bottomBuilder
-                                                                ?.call(
-                                                              context,
-                                                              controller.streamId ==
-                                                                      widget
-                                                                          .streamId
-                                                                  ? controller
-                                                                      .hostDetails
-                                                                  : null,
-                                                              controller
-                                                                  .descriptionController
-                                                                  .text,
-                                                            ) ??
-                                                            Column(
-                                                              mainAxisSize:
-                                                                  MainAxisSize
-                                                                      .min,
-                                                              children: [
-                                                                _buildChatView(
-                                                                  context,
-                                                                  isHost:
+                                                        child: Padding(
+                                                          padding: IsmLiveDimens
+                                                              .edgeInsets8_0,
+                                                          child: Row(
+                                                            crossAxisAlignment:
+                                                                CrossAxisAlignment
+                                                                    .end,
+                                                            children: [
+                                                              Expanded(
+                                                                child: IsmLiveApp
+                                                                        .bottomBuilder
+                                                                        ?.call(
+                                                                      context,
+                                                                      controller.streamId ==
+                                                                              widget.streamId
+                                                                          ? controller.hostDetails
+                                                                          : null,
                                                                       controller
-                                                                          .isHost,
-                                                                  streamId: widget
-                                                                      .streamId,
-                                                                ),
-                                                                IsmLiveDimens
-                                                                    .boxHeight8,
-                                                              ],
-                                                            ),
+                                                                          .descriptionController
+                                                                          .text,
+                                                                    ) ??
+                                                                    Column(
+                                                                      mainAxisSize:
+                                                                          MainAxisSize
+                                                                              .min,
+                                                                      children: [
+                                                                        _buildChatView(
+                                                                          context,
+                                                                          isHost:
+                                                                              controller.isHost,
+                                                                          streamId:
+                                                                              widget.streamId,
+                                                                        ),
+                                                                        IsmLiveDimens
+                                                                            .boxHeight8,
+                                                                      ],
+                                                                    ),
+                                                              ),
+                                                              if (!isKeyboardOpen)
+                                                                IsmLiveControlsWidget(
+                                                                    isHost: widget
+                                                                        .isHost,
+                                                                    isCopublishing:
+                                                                        controller
+                                                                            .isCopublisher,
+                                                                    streamId:
+                                                                        controller.streamId ??
+                                                                            '',
+                                                                    isKeyboardOpen:
+                                                                        isKeyboardOpen),
+                                                            ],
+                                                          ),
+                                                        ),
                                                       ),
-                                                      if (!isKeyboardOpen)
-                                                        IsmLiveControlsWidget(
-                                                            isHost:
-                                                                widget.isHost,
-                                                            isCopublishing:
-                                                                controller
-                                                                    .isCopublisher,
-                                                            streamId: controller
-                                                                    .streamId ??
-                                                                '',
-                                                            isKeyboardOpen:
-                                                                isKeyboardOpen),
+                                                      Padding(
+                                                        padding: EdgeInsets
+                                                            .symmetric(
+                                                                horizontal:
+                                                                    IsmLiveDimens
+                                                                        .twelve),
+                                                        child: Row(
+                                                          children: [
+                                                            Expanded(
+                                                              child: IsmLiveApp
+                                                                      .inputBuilder
+                                                                      ?.call(
+                                                                    context,
+                                                                    IsmLiveMessageField(
+                                                                      streamId:
+                                                                          controller.streamId ??
+                                                                              '',
+                                                                      isHost: controller
+                                                                          .isPublishing,
+                                                                      disabled:
+                                                                          !IsmLiveStreamId.isValid(
+                                                                              controller.streamId),
+                                                                    ),
+                                                                  ) ??
+                                                                  IsmLiveMessageField(
+                                                                    streamId:
+                                                                        controller.streamId ??
+                                                                            '',
+                                                                    isHost: controller
+                                                                        .isPublishing,
+                                                                    disabled: !IsmLiveStreamId.isValid(
+                                                                        controller
+                                                                            .streamId),
+                                                                  ),
+                                                            ),
+                                                            if (IsmLiveDelegate
+                                                                        .productStream ==
+                                                                    true &&
+                                                                !isKeyboardOpen) ...[
+                                                              // Determine button visibility and label based on conditions
+                                                              if (IsmLiveDelegate
+                                                                      .ecomConfigure
+                                                                      ?.hasPinnedProduct ??
+                                                                  false) ...[
+                                                                IsmLiveDimens
+                                                                    .boxWidth8,
+                                                                ConstrainedBox(
+                                                                  constraints:
+                                                                      BoxConstraints(
+                                                                    maxWidth: MediaQuery.of(context)
+                                                                            .size
+                                                                            .width *
+                                                                        0.5,
+                                                                  ),
+                                                                  child: controller
+                                                                              .isHost &&
+                                                                          (IsmLiveDelegate.ecomConfigure?.hasPinnedProduct ??
+                                                                              false)
+                                                                      ? _buildHostArrowButtons(
+                                                                          context)
+                                                                      : IsmLiveDelegate
+                                                                              .ecomConfigure
+                                                                              ?.buyNowButtonBuilder
+                                                                              ?.call(
+                                                                            context,
+                                                                            controller.streamId ??
+                                                                                '',
+                                                                            IsmLiveDelegate.ecomConfigure?.hasPinnedProduct ??
+                                                                                false,
+                                                                            controller.isHost,
+                                                                            () =>
+                                                                                _onBuyNowTap(context, controller),
+                                                                          ) ??
+                                                                          IsmLiveButton(
+                                                                            label:
+                                                                                'Buy now',
+                                                                            onTap: () =>
+                                                                                _onBuyNowTap(context, controller),
+                                                                          ),
+                                                                ),
+                                                              ]
+                                                            ]
+                                                          ],
+                                                        ),
+                                                      ),
+                                                      IsmLiveDimens.boxHeight8,
+                                                      if (IsmLiveApp
+                                                          .endStreamPosition
+                                                          .isBottomAligned)
+                                                        ...[],
+                                                      if (controller
+                                                          .showEmojiBoard)
+                                                        const IsmLiveEmojis(),
                                                     ],
                                                   ),
                                                 ),
-                                              ),
-                                              Padding(
-                                                padding: EdgeInsets.symmetric(
-                                                    horizontal:
-                                                        IsmLiveDimens.twelve),
-                                                child: Row(
-                                                  children: [
-                                                    Expanded(
-                                                      child: IsmLiveApp
-                                                              .inputBuilder
-                                                              ?.call(
-                                                            context,
-                                                            IsmLiveMessageField(
-                                                              streamId: controller
-                                                                      .streamId ??
-                                                                  '',
-                                                              isHost: controller
-                                                                  .isPublishing,
-                                                              disabled: !IsmLiveStreamId.isValid(
-                                                                      controller
-                                                                          .streamId),
-                                                            ),
-                                                          ) ??
-                                                          IsmLiveMessageField(
-                                                            streamId: controller
-                                                                    .streamId ??
-                                                                '',
-                                                            isHost: controller
-                                                                .isPublishing,
-                                                            disabled: !IsmLiveStreamId.isValid(
-                                                                    controller
-                                                                        .streamId),
-                                                          ),
-                                                    ),
-                                                    if (IsmLiveDelegate
-                                                                .productStream ==
-                                                            true &&
-                                                        !isKeyboardOpen) ...[
-                                                      // Determine button visibility and label based on conditions
-                                                      if (IsmLiveDelegate
-                                                              .ecomConfigure
-                                                              ?.hasPinnedProduct ??
-                                                          false) ...[
-                                                        IsmLiveDimens.boxWidth8,
-                                                        ConstrainedBox(
-                                                          constraints:
-                                                              BoxConstraints(
-                                                            maxWidth: MediaQuery.of(
-                                                                        context)
-                                                                    .size
-                                                                    .width *
-                                                                0.5,
-                                                          ),
-                                                          child: controller
-                                                                      .isHost &&
-                                                                  (IsmLiveDelegate
-                                                                          .ecomConfigure
-                                                                          ?.hasPinnedProduct ??
-                                                                      false)
-                                                              ? _buildHostArrowButtons(
-                                                                  context)
-                                                              : IsmLiveDelegate
-                                                                      .ecomConfigure
-                                                                      ?.buyNowButtonBuilder
-                                                                      ?.call(
-                                                                    context,
-                                                                    controller
-                                                                            .streamId ??
-                                                                        '',
-                                                                    IsmLiveDelegate
-                                                                            .ecomConfigure
-                                                                            ?.hasPinnedProduct ??
-                                                                        false,
-                                                                    controller
-                                                                        .isHost,
-                                                                    () => _onBuyNowTap(
-                                                                        context,
-                                                                        controller),
-                                                                  ) ??
-                                                                  IsmLiveButton(
-                                                                    label:
-                                                                        'Buy now',
-                                                                    onTap: () =>
-                                                                        _onBuyNowTap(
-                                                                            context,
-                                                                            controller),
-                                                                  ),
-                                                        ),
-                                                      ]
-                                                    ]
-                                                  ],
-                                                ),
-                                              ),
-                                              IsmLiveDimens.boxHeight8,
-                                              if (IsmLiveApp.endStreamPosition
-                                                  .isBottomAligned)
-                                                ...[],
-                                              if (controller.showEmojiBoard)
-                                                const IsmLiveEmojis(),
-                                            ],
-                                          ),
-                                        )
-                                      : widget.isSchedule &&
-                                              !IsmLiveStreamId.isValid(
-                                                  widget.streamId)
-                                          ? ScheduleStreamView(
-                                              isKeyboardOpen: isKeyboardOpen)
-                                          : const SizedBox.shrink(),
-                                ),
-                                if (IsmLiveDelegate.productStream == true &&
-                                    IsmLiveDelegate.ecomConfigure
-                                            ?.pinnedProductBuilder !=
-                                        null &&
-                                    !isKeyboardOpen)
-                                  GetBuilder<IsmLiveStreamController>(
-                                    id: IsmLiveMessageField.updateId,
-                                    builder: (controller) => Positioned(
-                                      right: IsmLiveDimens.sixteen,
-                                      bottom:
-                                          _calculateProductBuilderBottomPosition(
-                                                  controller) +
-                                              systemBottomInset,
-                                      child: IsmLiveDelegate.ecomConfigure!
-                                              .pinnedProductBuilder!(
-                                            context,
-                                            controller,
-                                          ) ??
-                                          const SizedBox.shrink(),
-                                    ),
+                                              )
+                                            : widget.isSchedule &&
+                                                    !IsmLiveStreamId.isValid(
+                                                        widget.streamId)
+                                                ? ScheduleStreamView(
+                                                    isKeyboardOpen:
+                                                        isKeyboardOpen)
+                                                : const SizedBox.shrink(),
                                   ),
-                                Align(
-                                  alignment: IsmLiveApp.endStreamPosition,
-                                  child: Padding(
-                                    padding: IsmLiveApp
-                                            .endStreamPosition.isBottomAligned
-                                        ? EdgeInsets.only(
-                                            bottom: systemBottomInset)
-                                        : EdgeInsets.zero,
-                                    child: IsmLiveApp.endButton ??
-                                        IsmLiveEndStreamButton(
-                                          onTapExit: () => IsmLiveApp.endStream(
-                                              context: context,
-                                              isSchedule: widget.isSchedule,
-                                              showViewerLeaveDialog: true),
-                                        ),
-                                  ),
-                                ),
-                                if (controller.isHost) ...[
-                                  Positioned(
-                                    bottom: IsmLiveDimens.eighty +
-                                        systemBottomInset,
-                                    left: IsmLiveDimens.sixteen,
-                                    child: const IsmLiveModerationWarning(),
-                                  ),
-                                  if (widget.isNewStream)
-                                    const IsmLiveCounterView(
-                                      onCompleteSheet: YourLiveSheet(),
-                                    ),
-                                ],
-                                if (controller.isPk &&
-                                    !(controller.pkStages?.isPkStart ??
-                                        false) &&
-                                    ((controller.userRole?.isPkGuest ??
-                                            false) ||
-                                        (controller.userRole?.isHost ??
-                                            false)) &&
-                                    !controller
-                                        .animationController.isCompleted &&
-                                    controller.participantTracks.length ==
-                                        2) ...[
-                                  AnimatedBuilder(
-                                    animation: controller.alignmentAnimation,
-                                    builder: (context, child) => AnimatedAlign(
-                                      alignment:
-                                          controller.alignmentAnimation.value,
-                                      duration: const Duration(
-                                        milliseconds: 100,
+                                  if (IsmLiveDelegate.productStream == true &&
+                                      IsmLiveDelegate.ecomConfigure
+                                              ?.pinnedProductBuilder !=
+                                          null &&
+                                      !isKeyboardOpen)
+                                    GetBuilder<IsmLiveStreamController>(
+                                      id: IsmLiveMessageField.updateId,
+                                      builder: (controller) => Positioned(
+                                        right: IsmLiveDimens.sixteen,
+                                        bottom:
+                                            _calculateProductBuilderBottomPosition(
+                                                    controller) +
+                                                systemBottomInset,
+                                        child: IsmLiveDelegate.ecomConfigure!
+                                                .pinnedProductBuilder!(
+                                              context,
+                                              controller,
+                                            ) ??
+                                            const SizedBox.shrink(),
                                       ),
-                                      child: const IsmLiveImage.svg(
-                                          IsmLiveAssetConstants.v),
                                     ),
-                                  ),
-                                  AnimatedBuilder(
-                                    animation:
-                                        controller.alignmentAnimationRight,
-                                    builder: (context, child) => AnimatedAlign(
-                                      alignment: controller
-                                          .alignmentAnimationRight.value,
-                                      duration: const Duration(
-                                        milliseconds: 100,
-                                      ),
-                                      child: const IsmLiveImage.svg(
-                                          IsmLiveAssetConstants.s),
-                                    ),
-                                  ),
-                                ],
-                                if ((controller.pkStages?.isPk ?? false) &&
-                                    controller
-                                        .animationController.isCompleted &&
-                                    (controller.userRole?.isHost ?? false) &&
-                                    !(controller.pkStages?.isPkStart ??
-                                        false) &&
-                                    controller.participantTracks.length == 2 &&
-                                    !(controller.pkStages?.isPkStop ?? false))
                                   Align(
-                                    alignment: Alignment.center,
-                                    child: IsmLiveTapHandler(
-                                      onTap: controller.pkChallengeSheet,
-                                      child: const IsmLiveImage.svg(
-                                        IsmLiveAssetConstants.start,
+                                    alignment: IsmLiveApp.endStreamPosition,
+                                    child: Padding(
+                                      padding: IsmLiveApp
+                                              .endStreamPosition.isBottomAligned
+                                          ? EdgeInsets.only(
+                                              bottom: overlayBottomPadding)
+                                          : EdgeInsets.zero,
+                                      child: IsmLiveApp.endButton ??
+                                          IsmLiveEndStreamButton(
+                                            onTapExit: () =>
+                                                IsmLiveApp.endStream(
+                                                    context: context,
+                                                    isSchedule:
+                                                        widget.isSchedule,
+                                                    showViewerLeaveDialog:
+                                                        true),
+                                          ),
+                                    ),
+                                  ),
+                                  if (controller.isHost) ...[
+                                    Positioned(
+                                      bottom: IsmLiveDimens.eighty +
+                                          overlayBottomPadding,
+                                      left: IsmLiveDimens.sixteen,
+                                      child: const IsmLiveModerationWarning(),
+                                    ),
+                                    if (widget.isNewStream)
+                                      const IsmLiveCounterView(
+                                        onCompleteSheet: YourLiveSheet(),
+                                      ),
+                                  ],
+                                  if (controller.isPk &&
+                                      !(controller.pkStages?.isPkStart ??
+                                          false) &&
+                                      ((controller.userRole?.isPkGuest ??
+                                              false) ||
+                                          (controller.userRole?.isHost ??
+                                              false)) &&
+                                      !controller
+                                          .animationController.isCompleted &&
+                                      controller.participantTracks.length ==
+                                          2) ...[
+                                    AnimatedBuilder(
+                                      animation: controller.alignmentAnimation,
+                                      builder: (context, child) =>
+                                          AnimatedAlign(
+                                        alignment:
+                                            controller.alignmentAnimation.value,
+                                        duration: const Duration(
+                                          milliseconds: 100,
+                                        ),
+                                        child: const IsmLiveImage.svg(
+                                            IsmLiveAssetConstants.v),
+                                      ),
+                                    ),
+                                    AnimatedBuilder(
+                                      animation:
+                                          controller.alignmentAnimationRight,
+                                      builder: (context, child) =>
+                                          AnimatedAlign(
+                                        alignment: controller
+                                            .alignmentAnimationRight.value,
+                                        duration: const Duration(
+                                          milliseconds: 100,
+                                        ),
+                                        child: const IsmLiveImage.svg(
+                                            IsmLiveAssetConstants.s),
+                                      ),
+                                    ),
+                                  ],
+                                  if ((controller.pkStages?.isPk ?? false) &&
+                                      controller
+                                          .animationController.isCompleted &&
+                                      (controller.userRole?.isHost ?? false) &&
+                                      !(controller.pkStages?.isPkStart ??
+                                          false) &&
+                                      controller.participantTracks.length ==
+                                          2 &&
+                                      !(controller.pkStages?.isPkStop ?? false))
+                                    Align(
+                                      alignment: Alignment.center,
+                                      child: IsmLiveTapHandler(
+                                        onTap: controller.pkChallengeSheet,
+                                        child: const IsmLiveImage.svg(
+                                          IsmLiveAssetConstants.start,
+                                        ),
+                                      ),
+                                    ),
+                                  if ((controller.pkStages?.isPkStart ??
+                                          false) &&
+                                      controller.participantTracks.length > 1)
+                                    const IsmLivePkTimerContainer(),
+                                  if ((controller.pkStages?.isPkStop ??
+                                          false) &&
+                                      controller.pkWinnerId == null)
+                                    const Align(
+                                      alignment: Alignment.center,
+                                      child: IsmLiveImage.svg(
+                                          IsmLiveAssetConstants.draw),
+                                    ),
+                                  Positioned.fill(
+                                    child: Obx(
+                                      () => Stack(
+                                        clipBehavior: Clip.none,
+                                        children: [
+                                          ...controller.heartList,
+                                          ...controller.giftList,
+                                        ],
                                       ),
                                     ),
                                   ),
-                                if ((controller.pkStages?.isPkStart ?? false) &&
-                                    controller.participantTracks.length > 1)
-                                  const IsmLivePkTimerContainer(),
-                                if ((controller.pkStages?.isPkStop ?? false) &&
-                                    controller.pkWinnerId == null)
-                                  const Align(
-                                    alignment: Alignment.center,
-                                    child: IsmLiveImage.svg(
-                                        IsmLiveAssetConstants.draw),
-                                  ),
-                                Positioned.fill(
-                                  child: Obx(
-                                    () => Stack(
-                                      clipBehavior: Clip.none,
-                                      children: [
-                                        ...controller.heartList,
-                                        ...controller.giftList,
-                                      ],
-                                    ),
-                                  ),
-                                ),
-                              ],
+                                ],
+                              ),
                             ),
                           ),
                         ),
-                      ),
                     ],
                   ),
                 ),
@@ -1281,7 +1299,11 @@ class ScheduleStreamView extends StatelessWidget {
   }
 
   @override
-  Widget build(BuildContext context) => SafeArea(
+  Widget build(BuildContext context) {
+    final keyboardBottom = MediaQuery.viewInsetsOf(context).bottom;
+    return SafeArea(
+      child: Padding(
+        padding: EdgeInsets.only(bottom: keyboardBottom),
         child: GetBuilder<IsmLiveStreamController>(
           builder: (controller) => Stack(
             children: [
@@ -1310,23 +1332,21 @@ class ScheduleStreamView extends StatelessWidget {
                                       IsmLiveMessageField(
                                         streamId: controller.streamId ?? '',
                                         isHost: controller.isPublishing,
-                                        disabled:
-                                            !IsmLiveStreamId.isValid(
-                                                controller.streamId),
+                                        disabled: !IsmLiveStreamId.isValid(
+                                            controller.streamId),
                                       ),
                                     ) ??
                                     IsmLiveMessageField(
                                       streamId: () {
                                         // Debug logging for streamId at line 903
-                                        final streamId =
-                                            controller.streamDetails?.streamId ??
-                                                '';
+                                        final streamId = controller
+                                                .streamDetails?.streamId ??
+                                            '';
                                         return streamId;
                                       }(),
                                       isHost: controller.isPublishing,
-                                      disabled:
-                                          !IsmLiveStreamId.isValid(
-                                              controller.streamDetails?.streamId),
+                                      disabled: !IsmLiveStreamId.isValid(
+                                          controller.streamDetails?.streamId),
                                     ),
                               ],
                             ),
@@ -1360,12 +1380,15 @@ class ScheduleStreamView extends StatelessWidget {
               Positioned.fill(
                 child: IgnorePointer(
                   ignoring:
-                      IsmLiveDelegate.scheduleStreamCenterOverlayBuilder == null,
+                      IsmLiveDelegate.scheduleStreamCenterOverlayBuilder ==
+                          null,
                   child: _buildCenterOverlay(context, controller),
                 ),
               ),
             ],
           ),
         ),
-      );
+      ),
+    );
+  }
 }

--- a/lib/src/views/stream/views/go_live_view.dart
+++ b/lib/src/views/stream/views/go_live_view.dart
@@ -79,7 +79,11 @@ class IsmGoLiveView extends StatelessWidget {
             controller.premiumStreamCoinsController.clear();
             controller.selectedGoLiveStream = IsmLiveStreamTypes.free;
             controller.pickedImage = null;
-            controller.descriptionController.clear();
+            controller.descriptionController.text =
+                IsmLiveDelegate.goLiveScreenConfigure
+                        ?.defaultBroadcastDescription ??
+                    IsmLiveDelegate.defaultBroadcastDescription ??
+                    '';
             controller.isHdBroadcast = IsmLiveDelegate
                     .goLiveScreenConfigure?.defaultHdBroadcastToggleValue ??
                 IsmLiveDelegate.defaultHdBroadcast ??

--- a/lib/src/views/stream/widgets/publisher_grid.dart
+++ b/lib/src/views/stream/widgets/publisher_grid.dart
@@ -15,21 +15,82 @@ String _participantProfileImageUrl(
   return '';
 }
 
-Widget _multiParticipantTile(IsmLiveStreamController controller, int index) =>
-    ParticipantWidget.widgetFor(
-      controller.participantList[index],
-      imageUrl: _participantProfileImageUrl(controller, index),
-      isFirstIndex: index == 0,
-      isViewer: !(controller.userRole?.isHost ?? false) &&
-          !(controller.userRole?.isPkGuest ?? false) &&
-          (controller.pkStages?.isPkStart ?? false),
-      isHost: index == 0,
-      showStatsLayer: controller.isPk,
-      isWinner: controller.pkWinnerId ==
-          controller.participantList[index].participant.identity,
-      isbattleFinish: (controller.pkStages?.isPkStop ?? false) &&
-          controller.pkWinnerId != null,
-    );
+String _participantFullName(IsmLiveStreamController controller, int index) {
+  final participant = controller.participantList[index].participant;
+  return ParticipantWidget.resolvedDisplayNameForParticipant(participant);
+}
+
+Widget _multiParticipantTile(
+  IsmLiveStreamController controller,
+  int index, {
+  required int participantCount,
+}) {
+  final base = ParticipantWidget.widgetFor(
+    controller.participantList[index],
+    imageUrl: _participantProfileImageUrl(controller, index),
+    isFirstIndex: index == 0,
+    isViewer: !(controller.userRole?.isHost ?? false) &&
+        !(controller.userRole?.isPkGuest ?? false) &&
+        (controller.pkStages?.isPkStart ?? false),
+    isHost: index == 0,
+    showStatsLayer: controller.isPk,
+    isWinner: controller.pkWinnerId ==
+        controller.participantList[index].participant.identity,
+    isbattleFinish: (controller.pkStages?.isPkStop ?? false) &&
+        controller.pkWinnerId != null,
+  );
+
+  final showName =
+      IsmLiveDelegate.showParticipantFullNamesInPublisherGrid &&
+          participantCount > 1;
+  if (!showName) {
+    return base;
+  }
+
+  final fullName = _participantFullName(controller, index);
+  if (fullName.isEmpty) {
+    return base;
+  }
+
+  return Stack(
+    fit: StackFit.expand,
+    clipBehavior: Clip.hardEdge,
+    children: [
+      base,
+      Positioned(
+        left: IsmLiveDimens.eight,
+        right: IsmLiveDimens.eight,
+        bottom: IsmLiveDimens.eight,
+        child: Align(
+          alignment: Alignment.bottomLeft,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              color: Colors.black.withValues(alpha: 0.55),
+              borderRadius: BorderRadius.circular(IsmLiveDimens.four),
+            ),
+            child: Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: IsmLiveDimens.eight,
+                vertical: IsmLiveDimens.four,
+              ),
+              child: Text(
+                fullName,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                textAlign: TextAlign.left,
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: IsmLiveDimens.twelve,
+                  fontWeight: FontWeight.w500,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    ],
+  );
+}
 
 class IsmLivePublisherGrid extends StatelessWidget {
   const IsmLivePublisherGrid({
@@ -118,6 +179,7 @@ class IsmLivePublisherGrid extends StatelessWidget {
                           child: _multiParticipantTile(
                             controller,
                             index,
+                            participantCount: participantCount,
                           ),
                         ),
                       ),
@@ -193,7 +255,11 @@ class IsmLivePublisherGrid extends StatelessWidget {
                                 childAspectRatio: aspectRatio,
                               ),
                               itemBuilder: (_, index) =>
-                                  _multiParticipantTile(controller, index),
+                                  _multiParticipantTile(
+                                    controller,
+                                    index,
+                                    participantCount: participantCount,
+                                  ),
                             ),
                           ),
                         ),

--- a/lib/src/views/stream/widgets/publisher_grid.dart
+++ b/lib/src/views/stream/widgets/publisher_grid.dart
@@ -126,8 +126,21 @@ class IsmLivePublisherGrid extends StatelessWidget {
 
                   final topPad = IsmLiveDimens.hundred;
 
+                  final mq = MediaQuery.of(context);
+                  final imeBottom = mq.viewInsets.bottom;
+                  final viewportCap =
+                      max(1.0, mq.size.height - mq.viewPadding.vertical);
+                  // Ancestors may shrink [constraints.maxHeight] when the IME is open.
+                  // Use full-viewport height for grid math so tiles match the full-bleed
+                  // video layer; [UnconstrainedBox] below lets this paint past the
+                  // shrunk layout box when needed (stream Stack uses [Clip.none]).
+                  final layoutViewportHeight = min(
+                    constraints.maxHeight + imeBottom,
+                    viewportCap,
+                  );
+
                   final maxGridHeight =
-                      max(1.0, constraints.maxHeight - topPad);
+                      max(1.0, layoutViewportHeight - topPad);
                   final crossCount = participantCount < 3 ? 2 : 3;
                   final rowCount =
                       (participantCount + crossCount - 1) ~/ crossCount;
@@ -150,29 +163,39 @@ class IsmLivePublisherGrid extends StatelessWidget {
                   );
                   final mainExtent =
                       (gridHeight - (rowCount - 1) * mainSpacing) / rowCount;
-                  final aspectRatio =
-                      (crossExtent / mainExtent).clamp(0.25, 4.0);
+                  // childAspectRatio = cross/main. An upper clamp (e.g. 4.0) made
+                  // cells taller than [mainExtent], clipping the last row when
+                  // height is tight (IME). Keep only a small positive floor.
+                  final aspectRatio = max(crossExtent / mainExtent, 0.02);
 
                   return Align(
                     alignment: Alignment.topCenter,
-                    child: Padding(
-                      padding: EdgeInsets.only(top: topPad),
+                    child: UnconstrainedBox(
+                      constrainedAxis: Axis.horizontal,
+                      clipBehavior: Clip.none,
                       child: SizedBox(
                         width: constraints.maxWidth,
-                        height: gridHeight,
-                        child: GridView.builder(
-                          restorationId: '',
-                          itemCount: participantCount,
-                          physics: const NeverScrollableScrollPhysics(),
-                          gridDelegate:
-                              SliverGridDelegateWithFixedCrossAxisCount(
-                            crossAxisCount: crossCount,
-                            mainAxisSpacing: mainSpacing,
-                            crossAxisSpacing: crossSpacing,
-                            childAspectRatio: aspectRatio,
+                        height: layoutViewportHeight,
+                        child: Padding(
+                          padding: EdgeInsets.only(top: topPad),
+                          child: SizedBox(
+                            width: constraints.maxWidth,
+                            height: gridHeight,
+                            child: GridView.builder(
+                              restorationId: '',
+                              itemCount: participantCount,
+                              physics: const NeverScrollableScrollPhysics(),
+                              gridDelegate:
+                                  SliverGridDelegateWithFixedCrossAxisCount(
+                                crossAxisCount: crossCount,
+                                mainAxisSpacing: mainSpacing,
+                                crossAxisSpacing: crossSpacing,
+                                childAspectRatio: aspectRatio,
+                              ),
+                              itemBuilder: (_, index) =>
+                                  _multiParticipantTile(controller, index),
+                            ),
                           ),
-                          itemBuilder: (_, index) =>
-                              _multiParticipantTile(controller, index),
                         ),
                       ),
                     ),

--- a/lib/src/views/stream/widgets/stream_header.dart
+++ b/lib/src/views/stream/widgets/stream_header.dart
@@ -447,42 +447,67 @@ class _ExpandableDescription extends StatefulWidget {
 
 class _ExpandableDescriptionState extends State<_ExpandableDescription> {
   bool _isExpanded = false;
-  late bool _showViewMore;
 
   @override
-  void initState() {
-    super.initState();
-    // Simple heuristic: show "View more" if text is longer than 80 characters
-    // This is a reasonable estimate for 2 lines of text
-    _showViewMore = widget.description.length > 80;
+  void didUpdateWidget(_ExpandableDescription oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.description != oldWidget.description ||
+        widget.textStyle != oldWidget.textStyle) {
+      _isExpanded = false;
+    }
+  }
+
+  /// True when the description needs more than two lines at [maxWidth].
+  bool _textExceedsTwoLines(double maxWidth, BuildContext context) {
+    if (widget.description.isEmpty ||
+        maxWidth <= 0 ||
+        !maxWidth.isFinite) {
+      return false;
+    }
+    final painter = TextPainter(
+      text: TextSpan(text: widget.description, style: widget.textStyle),
+      textDirection: Directionality.of(context),
+      maxLines: 2,
+      textScaler: MediaQuery.textScalerOf(context),
+      locale: Localizations.maybeLocaleOf(context),
+    );
+    painter.layout(maxWidth: maxWidth);
+    return painter.didExceedMaxLines;
   }
 
   @override
-  Widget build(BuildContext context) => Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            widget.description,
-            style: widget.textStyle,
-            maxLines: _isExpanded ? null : 2,
-            overflow:
-                _isExpanded ? TextOverflow.visible : TextOverflow.ellipsis,
-          ),
-          if (_showViewMore) ...[
-            IsmLiveDimens.boxHeight4,
-            IsmLiveTapHandler(
-              onTap: () {
-                setState(() {
-                  _isExpanded = !_isExpanded;
-                });
-              },
-              child: Text(
-                _isExpanded ? 'View less' : 'View more',
-                style: widget.textStyle?.copyWith(
-                    color: Colors.white, fontWeight: FontWeight.bold),
+  Widget build(BuildContext context) => LayoutBuilder(
+        builder: (context, constraints) {
+          final showToggle =
+              _textExceedsTwoLines(constraints.maxWidth, context);
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                widget.description,
+                style: widget.textStyle,
+                maxLines: _isExpanded ? null : 2,
+                overflow: _isExpanded
+                    ? TextOverflow.visible
+                    : TextOverflow.ellipsis,
               ),
-            ),
-          ],
-        ],
+              if (showToggle) ...[
+                IsmLiveDimens.boxHeight4,
+                IsmLiveTapHandler(
+                  onTap: () {
+                    setState(() {
+                      _isExpanded = !_isExpanded;
+                    });
+                  },
+                  child: Text(
+                    _isExpanded ? 'View less' : 'View more',
+                    style: widget.textStyle?.copyWith(
+                        color: Colors.white, fontWeight: FontWeight.bold),
+                  ),
+                ),
+              ],
+            ],
+          );
+        },
       );
 }

--- a/lib/src/widgets/participant.dart
+++ b/lib/src/widgets/participant.dart
@@ -56,6 +56,12 @@ abstract class ParticipantWidget extends StatefulWidget {
     throw UnimplementedError('Unknown participant type');
   }
 
+  /// Display label aligned with participant tiles: JSON metadata
+  /// (`firstName` / `lastName` / `username`), then LiveKit [Participant.name],
+  /// then [Participant.identity].
+  static String resolvedDisplayNameForParticipant(Participant participant) =>
+      _participantUiData(participant, null).displayName;
+
   // Must be implemented by child class
   abstract final Participant participant;
   abstract final String? imageUrl;


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new feature that displays participants' full names in the publisher grid when multiple participants are shown. Specifically, it adds a toggle controlled by the `showParticipantFullNamesInPublisherGrid` flag, which, when enabled, overlays each participant's full name (or fallback to their LiveKit name or ID) at the bottom-left corner of their video tile. Additionally, the default broadcast description in the "Go Live" screen is set to a predefined string ("Hey dubly!") if not specified. These changes enhance the user interface by providing clearer identification of participants in multi-user streams and improve the default stream setup experience.
<!-- kody-pr-summary:end -->