### PR TITLE
Feat: Added support 'streamBottomWidgetBuilder'

### DIFF
--- a/example/lib/controllers/home/home_controller.dart
+++ b/example/lib/controllers/home/home_controller.dart
@@ -76,8 +76,31 @@ class HomeController extends GetxController {
       showParticipantFullNamesInPublisherGrid : true,
       productionMode: true,
       // Remove `const` if you uncomment builders or callbacks below.
+      streamScreenConfigure: IsmLiveStreamScreenConfigure(
+        streamBottomWidgetBuilder:
+            (context, streamId, isHost, isKeyboardOpen) {
+          if (isKeyboardOpen || streamId.isEmpty) {
+            return null;
+          }
+          return Container(
+            margin: const EdgeInsets.symmetric(horizontal: 12),
+            padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+            decoration: BoxDecoration(
+              color: Colors.white.withValues(alpha: 0.2),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: Text(
+              isHost
+                  ? 'Host custom bottom bar'
+                  : 'Viewer custom bottom bar',
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: Colors.white, fontSize: 12),
+            ),
+          );
+        },
+      ),
       goLiveScreenConfigure: const IsmLiveGoLiveScreenConfigure(
-        isProductStreamFeatureEnabled: false,
+        isProductStreamFeatureEnabled: true,
         isScheduleStreamFeatureEnabled: true,
         defaultBroadcastDescription: "Hey dubly!"
         // Feature flags:

--- a/lib/src/live_app.dart
+++ b/lib/src/live_app.dart
@@ -629,6 +629,7 @@ class IsmLiveApp extends StatefulWidget {
     bool productionMode = false,
     IsmLiveEcomConfigure? ecomConfigure,
     IsmLiveGoLiveScreenConfigure? goLiveScreenConfigure,
+    IsmLiveStreamScreenConfigure? streamScreenConfigure,
     bool enableFreeGift = false,
     bool restrictProfileSheetOnProfileClick = false,
     String? fontFamily,
@@ -677,6 +678,8 @@ class IsmLiveApp extends StatefulWidget {
         sideIconsConfigure ?? const IsmLiveSideIconsConfigure();
     final resolvedGoLiveScreenConfigure =
         goLiveScreenConfigure ?? const IsmLiveGoLiveScreenConfigure();
+    final resolvedStreamScreenConfigure =
+        streamScreenConfigure ?? const IsmLiveStreamScreenConfigure();
 
     // assert(_initialized,
     //     'IsmLiveApp is not initialized, initialize it using `IsmLiveApp.initialize()`');
@@ -730,6 +733,7 @@ class IsmLiveApp extends StatefulWidget {
     IsmLiveDelegate.productionMode = productionMode;
     IsmLiveDelegate.ecomConfigure = ecomConfigure;
     IsmLiveDelegate.goLiveScreenConfigure = resolvedGoLiveScreenConfigure;
+    IsmLiveDelegate.streamScreenConfigure = resolvedStreamScreenConfigure;
     IsmLiveDelegate.enableFreeGift = enableFreeGift;
     IsmLiveDelegate.restrictProfileSheetOnProfileClick =
         restrictProfileSheetOnProfileClick;
@@ -1043,6 +1047,9 @@ class IsmLiveApp extends StatefulWidget {
 
   static IsmLiveGoLiveScreenConfigure? get goLiveScreenConfigure =>
       IsmLiveDelegate.goLiveScreenConfigure;
+
+  static IsmLiveStreamScreenConfigure get streamScreenConfigure =>
+      IsmLiveDelegate.streamScreenConfigure;
 
   static String? get fontFamily => IsmLiveDelegate.fontFamily;
 

--- a/lib/src/live_delegate.dart
+++ b/lib/src/live_delegate.dart
@@ -1131,6 +1131,10 @@ class IsmLiveDelegate {
 
   static IsmLiveGoLiveScreenConfigure? goLiveScreenConfigure;
 
+  /// Configuration for the live stream screen UI.
+  static IsmLiveStreamScreenConfigure streamScreenConfigure =
+      const IsmLiveStreamScreenConfigure();
+
   static bool enableFreeGift = false;
 
   static bool restrictProfileSheetOnProfileClick = false;
@@ -1371,6 +1375,31 @@ class IsmLiveEcomConfigure {
 
   /// Gets the current pinned product status dynamically
   bool get hasPinnedProduct => hasPinnedProductGetter?.call() ?? false;
+}
+
+/// Builder for a full-width widget at the bottom of the live stream screen,
+/// rendered directly below the message input row.
+///
+/// Return `null` to hide the widget for the current state (e.g. when the
+/// keyboard is open).
+typedef StreamBottomWidgetBuilder = Widget? Function(
+  BuildContext context,
+  String streamId,
+  bool isHost,
+  bool isKeyboardOpen,
+);
+
+/// Configuration for the live stream screen UI.
+///
+/// Set via `IsmLiveApp.configureInterface(streamScreenConfigure: ...)`.
+class IsmLiveStreamScreenConfigure {
+  const IsmLiveStreamScreenConfigure({
+    this.streamBottomWidgetBuilder,
+  });
+
+  /// Full-width widget shown at the bottom of the stream screen, below the
+  /// message input row.
+  final StreamBottomWidgetBuilder? streamBottomWidgetBuilder;
 }
 
 /// Configuration class for GoLive screen customization.

--- a/lib/src/views/stream/stream_view.dart
+++ b/lib/src/views/stream/stream_view.dart
@@ -265,6 +265,31 @@ class _IsmLiveStreamViewState extends State<_IsmLiveStreamView> {
     setState(() => _overlaysVisible = !_overlaysVisible);
   }
 
+  /// Full-width widgets from [IsmLiveStreamScreenConfigure.streamBottomWidgetBuilder].
+  List<Widget> _streamBottomWidgets(
+    BuildContext context,
+    IsmLiveStreamController controller,
+    bool isKeyboardOpen,
+  ) {
+    final widget = IsmLiveDelegate
+        .streamScreenConfigure.streamBottomWidgetBuilder
+        ?.call(
+      context,
+      controller.streamId ?? '',
+      controller.isHost,
+      isKeyboardOpen,
+    );
+    if (widget == null) {
+      return const [];
+    }
+    return [
+      SizedBox(
+        width: double.infinity,
+        child: widget,
+      ),
+    ];
+  }
+
   /// Builds two arrow buttons for hosts with customizable size
   Widget _buildHostArrowButtons(BuildContext context, {double? size}) =>
       GetBuilder<IsmLiveStreamController>(
@@ -745,6 +770,11 @@ class _IsmLiveStreamViewState extends State<_IsmLiveStreamView> {
                                                             ]
                                                           ],
                                                         ),
+                                                      ),
+                                                      ..._streamBottomWidgets(
+                                                        context,
+                                                        controller,
+                                                        isKeyboardOpen,
                                                       ),
                                                       IsmLiveDimens.boxHeight8,
                                                       if (IsmLiveApp


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces support for a customizable bottom widget in the live stream screen. It adds a new configuration option, `streamBottomWidgetBuilder`, allowing developers to define a full-width widget that appears at the bottom of the stream interface, below the message input area. The feature can be conditionally hidden when the keyboard is open or based on other stream states. The implementation includes updates to configuration classes, the main app widget, and the stream view to facilitate rendering the custom bottom widget dynamically during the live stream.
<!-- kody-pr-summary:end -->