### PR TITLE
Feat: comment replay

### DIFF
--- a/example/lib/controllers/home/home_controller.dart
+++ b/example/lib/controllers/home/home_controller.dart
@@ -243,6 +243,7 @@ class HomeController extends GetxController {
       bottomSheetBorderRadius:
           const BorderRadius.vertical(top: Radius.circular(12)),
       streamRecordingPlayerConfig: IsmLiveStreamRecordingPlayerConfig(
+        showChatReplay: true,
         onControlOption: (context, option, recording) async {
           await showModalBottomSheet<void>(
             context: context,

--- a/lib/src/delegate/live_delegate_recording_types.dart
+++ b/lib/src/delegate/live_delegate_recording_types.dart
@@ -79,6 +79,12 @@ typedef IsmLiveStreamRecordingRightControlsBuilder = Widget Function(
   IsmLiveStreamRecordingPlayerConfig config,
 );
 
+/// Resolves stream start time for chat replay when the recording item does not
+/// implement [IsmLiveStreamRecordingReplayCapable].
+typedef IsmLiveStreamRecordingResolveStartTimeCallback = DateTime? Function(
+  IsmLiveStreamRecordingItem recording,
+);
+
 /// Configuration for the Stream Recording Player.
 ///
 /// Use [onLoaded] for initial-load logic (e.g. record view count, fetch products).
@@ -92,6 +98,8 @@ class IsmLiveStreamRecordingPlayerConfig {
     this.topControlsBuilder,
     this.bottomControlsBuilder,
     this.rightControlsBuilder,
+    this.showChatReplay = false,
+    this.resolveStreamStartTime,
   });
 
   /// Optional. For "my stream" vs others.
@@ -117,4 +125,10 @@ class IsmLiveStreamRecordingPlayerConfig {
 
   /// Optional. If provided, replaces [IsmLiveStreamRecordingRightControls] widget.
   final IsmLiveStreamRecordingRightControlsBuilder? rightControlsBuilder;
+
+  /// When true, replays stream chat comments in sync with video playback.
+  final bool showChatReplay;
+
+  /// Optional fallback when start time is not available on the recording item.
+  final IsmLiveStreamRecordingResolveStartTimeCallback? resolveStreamStartTime;
 }

--- a/lib/src/models/stream/get_message_model.dart
+++ b/lib/src/models/stream/get_message_model.dart
@@ -15,6 +15,8 @@ class IsmLiveGetMessageModel {
     this.lastMessageTimestamp,
     this.customType,
     this.messageType,
+    this.activeStream,
+    this.archived,
   });
 
   factory IsmLiveGetMessageModel.fromMap(Map<String, dynamic> map) =>
@@ -30,6 +32,8 @@ class IsmLiveGetMessageModel {
         lastMessageTimestamp: map['lastMessageTimestamp'] as int?,
         customType: (map['customType'] as List<dynamic>? ?? []).cast<String>(),
         messageType: (map['messageType'] as List<dynamic>? ?? []).cast<int>(),
+        activeStream: map['activeStream'] as bool?,
+        archived: map['archived'] as bool?,
       );
 
   factory IsmLiveGetMessageModel.fromJson(String source) =>
@@ -47,6 +51,12 @@ class IsmLiveGetMessageModel {
   final List<String>? customType;
   final List<int>? messageType;
 
+  /// When false, fetches messages for inactive/ended streams. Omit for live chat.
+  final bool? activeStream;
+
+  /// When true, fetches archived messages for recorded streams. Omit for live chat.
+  final bool? archived;
+
   IsmLiveGetMessageModel copyWith({
     String? streamId,
     int? sort,
@@ -59,6 +69,8 @@ class IsmLiveGetMessageModel {
     int? lastMessageTimestamp,
     List<String>? customType,
     List<int>? messageType,
+    bool? activeStream,
+    bool? archived,
   }) =>
       IsmLiveGetMessageModel(
         streamId: streamId ?? this.streamId,
@@ -72,6 +84,8 @@ class IsmLiveGetMessageModel {
         lastMessageTimestamp: lastMessageTimestamp ?? this.lastMessageTimestamp,
         customType: customType ?? this.customType,
         messageType: messageType ?? this.messageType,
+        activeStream: activeStream ?? this.activeStream,
+        archived: archived ?? this.archived,
       );
 
   Map<String, dynamic> toMap() => <String, dynamic>{
@@ -86,13 +100,15 @@ class IsmLiveGetMessageModel {
         'lastMessageTimestamp': lastMessageTimestamp,
         'customType': customType,
         'messageType': messageType,
+        'activeStream': activeStream,
+        'archived': archived,
       };
 
   String toJson() => json.encode(toMap());
 
   @override
   String toString() =>
-      'IsmLiveGetMessageModel(streamId: $streamId, sort: $sort, skip: $skip, limit: $limit, senderIdsExclusive: $senderIdsExclusive, searchTag: $searchTag, ids: $ids, senderIds: $senderIds, lastMessageTimestamp: $lastMessageTimestamp, customType: $customType, messageType: $messageType)';
+      'IsmLiveGetMessageModel(streamId: $streamId, sort: $sort, skip: $skip, limit: $limit, senderIdsExclusive: $senderIdsExclusive, searchTag: $searchTag, ids: $ids, senderIds: $senderIds, lastMessageTimestamp: $lastMessageTimestamp, customType: $customType, messageType: $messageType, activeStream: $activeStream, archived: $archived)';
 
   @override
   bool operator ==(covariant IsmLiveGetMessageModel other) {
@@ -108,7 +124,9 @@ class IsmLiveGetMessageModel {
         listEquals(other.senderIds, senderIds) &&
         other.lastMessageTimestamp == lastMessageTimestamp &&
         listEquals(other.customType, customType) &&
-        listEquals(other.messageType, messageType);
+        listEquals(other.messageType, messageType) &&
+        other.activeStream == activeStream &&
+        other.archived == archived;
   }
 
   @override
@@ -123,5 +141,7 @@ class IsmLiveGetMessageModel {
       senderIds.hashCode ^
       lastMessageTimestamp.hashCode ^
       customType.hashCode ^
-      messageType.hashCode;
+      messageType.hashCode ^
+      activeStream.hashCode ^
+      archived.hashCode;
 }

--- a/lib/src/models/stream_recording/stream_data_model_recording_adapter.dart
+++ b/lib/src/models/stream_recording/stream_data_model_recording_adapter.dart
@@ -3,7 +3,9 @@ import 'package:appscrip_live_stream_component/appscrip_live_stream_component.da
 /// Adapts [IsmLiveStreamDataModel] to [IsmLiveStreamRecordingItem] for use in
 /// the recording player.
 class IsmLiveStreamDataModelRecordingAdapter
-    implements IsmLiveStreamRecordingItem {
+    implements
+        IsmLiveStreamRecordingItem,
+        IsmLiveStreamRecordingReplayCapable {
   IsmLiveStreamDataModelRecordingAdapter(this._model);
 
   final IsmLiveStreamDataModel _model;
@@ -37,4 +39,7 @@ class IsmLiveStreamDataModelRecordingAdapter
 
   @override
   String? get thumbnailUrl => _model.streamImage;
+
+  @override
+  DateTime? get streamStartTime => _model.startDateTime;
 }

--- a/lib/src/models/stream_recording/stream_recording_item.dart
+++ b/lib/src/models/stream_recording/stream_recording_item.dart
@@ -27,3 +27,13 @@ abstract class IsmLiveStreamRecordingItem {
   /// Poster or thumbnail URL for this recording (e.g. preview before playback).
   String? get thumbnailUrl;
 }
+
+/// Optional capability for chat replay sync on a recording item.
+///
+/// Host apps that `implement` [IsmLiveStreamRecordingItem] are not required to
+/// adopt this interface. Chat replay can use config `resolveStreamStartTime`
+/// or the first message timestamp when start time is unavailable.
+abstract class IsmLiveStreamRecordingReplayCapable {
+  /// When the live stream started. Used to align comments with video position.
+  DateTime? get streamStartTime;
+}

--- a/lib/src/utils/recording_chat_helper.dart
+++ b/lib/src/utils/recording_chat_helper.dart
@@ -1,0 +1,211 @@
+import 'package:appscrip_live_stream_component/appscrip_live_stream_component.dart';
+import 'package:get/get.dart';
+
+/// Fetches and converts stream chat messages for recording replay.
+///
+/// Uses the same messages API as live streams but keeps results isolated from
+/// [IsmLiveStreamController.streamMessagesList].
+/// Resolves stream start time for recording chat replay.
+DateTime? ismLiveRecordingStreamStartTime(
+  IsmLiveStreamRecordingItem recording,
+  IsmLiveStreamRecordingPlayerConfig config,
+) {
+  final fromConfig = config.resolveStreamStartTime?.call(recording);
+  if (fromConfig != null) {
+    return fromConfig;
+  }
+  if (recording is IsmLiveStreamRecordingReplayCapable) {
+    return (recording as IsmLiveStreamRecordingReplayCapable).streamStartTime;
+  }
+  return null;
+}
+
+class _ResolvedRecordedMessageQuery {
+  const _ResolvedRecordedMessageQuery({
+    required this.query,
+    required this.count,
+  });
+
+  final IsmLiveGetMessageModel query;
+  final int count;
+}
+
+class IsmLiveRecordingChatHelper {
+  const IsmLiveRecordingChatHelper._();
+
+  static const int _defaultPageSize = 50;
+
+  /// Base query for ended/recorded streams (`activeStream=false`).
+  ///
+  /// Pass [useArchived] to also request archived messages after the initial
+  /// attempt returns no data.
+  static IsmLiveGetMessageModel _recordedStreamMessageQuery(
+    String streamId, {
+    bool useArchived = false,
+  }) =>
+      IsmLiveGetMessageModel(
+        streamId: streamId,
+        messageType: [IsmLiveMessageType.normal.value],
+        activeStream: false,
+        archived: useArchived ? true : null,
+      );
+
+  static IsmLiveStreamViewModel _viewModel() {
+    if (!Get.isRegistered<IsmLiveStreamController>()) {
+      IsmLiveStreamBinding().dependencies();
+    }
+    return Get.find<IsmLiveStreamController>().viewModel;
+  }
+
+  /// Picks the recording message query params for this stream.
+  ///
+  /// 1. Try `activeStream=false`.
+  /// 2. If count is zero or the first page is empty, retry with
+  ///    `activeStream=false` and `archived=true`.
+  /// 3. All pagination for this recording uses the resolved params.
+  static Future<_ResolvedRecordedMessageQuery> _resolveRecordedMessageQuery(
+    String streamId,
+    IsmLiveStreamViewModel viewModel,
+  ) async {
+    final inactiveQuery = _recordedStreamMessageQuery(streamId);
+    final inactiveCount = await viewModel.fetchMessagesCount(
+      showLoading: false,
+      getMessageModel: inactiveQuery,
+    );
+    if (inactiveCount > 0) {
+      final firstPage = await viewModel.fetchMessages(
+        showLoading: false,
+        showDialog: false,
+        getMessageModel: inactiveQuery.copyWith(
+          sort: 1,
+          skip: 0,
+          limit: 1,
+          senderIdsExclusive: false,
+        ),
+      );
+      if (firstPage.isNotEmpty) {
+        return _ResolvedRecordedMessageQuery(
+          query: inactiveQuery,
+          count: inactiveCount,
+        );
+      }
+    }
+
+    final archivedQuery = _recordedStreamMessageQuery(
+      streamId,
+      useArchived: true,
+    );
+    final archivedCount = await viewModel.fetchMessagesCount(
+      showLoading: false,
+      getMessageModel: archivedQuery,
+    );
+    return _ResolvedRecordedMessageQuery(
+      query: archivedQuery,
+      count: archivedCount,
+    );
+  }
+
+  /// Loads all normal chat messages for [streamId], oldest first.
+  static Future<List<IsmLiveChatModel>> fetchAllChatMessages({
+    required String streamId,
+    String? hostUserId,
+    String? currentUserId,
+    int pageSize = _defaultPageSize,
+  }) async {
+    if (streamId.isEmpty) {
+      return const [];
+    }
+
+    final viewModel = _viewModel();
+    final resolved = await _resolveRecordedMessageQuery(streamId, viewModel);
+    if (resolved.count <= 0) {
+      return const [];
+    }
+
+    final allMessages = <IsmLiveMessageModel>[];
+    final safePageSize = pageSize <= 0 ? _defaultPageSize : pageSize;
+
+    for (var skip = 0; skip < resolved.count; skip += safePageSize) {
+      final remaining = resolved.count - skip;
+      final limit = remaining < safePageSize ? remaining : safePageSize;
+      final batch = await viewModel.fetchMessages(
+        showLoading: false,
+        showDialog: false,
+        getMessageModel: resolved.query.copyWith(
+          sort: 1,
+          skip: skip,
+          limit: limit,
+          senderIdsExclusive: false,
+        ),
+      );
+      allMessages.addAll(batch);
+    }
+
+    final chats = allMessages
+        .map(
+          (message) => _convertMessageToChat(
+            message,
+            streamId: streamId,
+            hostUserId: hostUserId,
+            currentUserId: currentUserId,
+          ),
+        )
+        .whereType<IsmLiveChatModel>()
+        .toList()
+      ..sort(
+        (a, b) => a.timeStamp.millisecondsSinceEpoch
+            .compareTo(b.timeStamp.millisecondsSinceEpoch),
+      );
+
+    return chats;
+  }
+
+  static IsmLiveChatModel? _convertMessageToChat(
+    IsmLiveMessageModel message, {
+    required String streamId,
+    String? hostUserId,
+    String? currentUserId,
+  }) {
+    final processed = _processMessage(message, streamId);
+    if (processed == null) {
+      return null;
+    }
+
+    return IsmLiveChatModel(
+      streamId: processed.streamId.isEmpty ? streamId : processed.streamId,
+      messageId: processed.messageId,
+      userId: processed.senderId,
+      userIdentifier: processed.senderIdentifier,
+      userName: processed.senderName,
+      fullName: processed.name,
+      imageUrl: processed.senderProfileImageUrl ?? '',
+      body: processed.body,
+      timeStamp: DateTime.fromMillisecondsSinceEpoch(processed.sentAt),
+      sentByMe: currentUserId != null && processed.senderId == currentUserId,
+      sentByHost: hostUserId != null && processed.senderId == hostUserId,
+      isReply: processed.replyMessage,
+      parentId: processed.parentMessageId,
+      parentBody: processed.metaData?.parentMessageBody,
+      isEvent: processed.isEvent,
+      isCopublisherRequest: processed.isCopublisherRequest,
+    );
+  }
+
+  static IsmLiveMessageModel? _processMessage(
+    IsmLiveMessageModel message,
+    String streamId,
+  ) {
+    final callback =
+        IsmLiveDelegate.streamScreenConfigure.messageProcessCallback;
+    if (callback == null) {
+      return message;
+    }
+
+    return callback.call(
+      message,
+      streamId,
+      false,
+      false,
+    );
+  }
+}

--- a/lib/src/views/stream_recording/stream_recording_player_view.dart
+++ b/lib/src/views/stream_recording/stream_recording_player_view.dart
@@ -329,6 +329,7 @@ class _IsmLiveStreamRecordingPlayerViewState
                   if (_showOverlay)
                     _RecordingOverlay(
                       recording: recording,
+                      isActive: isActive,
                       playerKey: playerKey,
                       videoController: overlayController,
                       config: config,
@@ -349,6 +350,7 @@ class _IsmLiveStreamRecordingPlayerViewState
 class _RecordingOverlay extends StatelessWidget {
   const _RecordingOverlay({
     required this.recording,
+    required this.isActive,
     required this.playerKey,
     required this.videoController,
     required this.config,
@@ -357,6 +359,7 @@ class _RecordingOverlay extends StatelessWidget {
   });
 
   final IsmLiveStreamRecordingItem recording;
+  final bool isActive;
   final GlobalKey playerKey;
   final VideoPlayerController? videoController;
   final IsmLiveStreamRecordingPlayerConfig config;
@@ -450,6 +453,13 @@ class _RecordingOverlay extends StatelessWidget {
                   ),
             ),
           ),
+          if (config.showChatReplay)
+            IsmLiveRecordingChatOverlay(
+              recording: recording,
+              config: config,
+              videoController: videoController,
+              isActive: isActive,
+            ),
           // Center overlay: hide while actively playing; show a loader while the
           // player is buffering (e.g. after a seek); show play only when paused.
           if (!isVideoReady)

--- a/lib/src/views/stream_recording/widgets/recording_chat_overlay.dart
+++ b/lib/src/views/stream_recording/widgets/recording_chat_overlay.dart
@@ -1,0 +1,401 @@
+import 'dart:async';
+
+import 'package:appscrip_live_stream_component/appscrip_live_stream_component.dart';
+import 'package:appscrip_live_stream_component/src/utils/recording_chat_helper.dart';
+import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+
+/// Read-only chat overlay for stream recording replay.
+///
+/// Reveals comments in sync with [videoController] position using
+/// [IsmLiveStreamRecordingReplayCapable.streamStartTime] (or a fallback baseline).
+class IsmLiveRecordingChatOverlay extends StatefulWidget {
+  const IsmLiveRecordingChatOverlay({
+    super.key,
+    required this.recording,
+    required this.config,
+    required this.videoController,
+    required this.isActive,
+  });
+
+  final IsmLiveStreamRecordingItem recording;
+  final IsmLiveStreamRecordingPlayerConfig config;
+  final VideoPlayerController? videoController;
+  final bool isActive;
+
+  @override
+  State<IsmLiveRecordingChatOverlay> createState() =>
+      _IsmLiveRecordingChatOverlayState();
+}
+
+class _IsmLiveRecordingChatOverlayState
+    extends State<IsmLiveRecordingChatOverlay> {
+  final ScrollController _scrollController = ScrollController();
+
+  List<IsmLiveChatModel> _allMessages = const [];
+  List<IsmLiveChatModel> _visibleMessages = const [];
+  DateTime? _fallbackStartTime;
+  bool _isLoading = false;
+  int _loadGeneration = 0;
+  int _previousVisibleCount = 0;
+  bool _isAtBottom = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+    widget.videoController?.addListener(_onVideoTick);
+    if (widget.isActive) {
+      unawaited(_loadMessages());
+    }
+  }
+
+  @override
+  void didUpdateWidget(IsmLiveRecordingChatOverlay oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.videoController != widget.videoController) {
+      oldWidget.videoController?.removeListener(_onVideoTick);
+      widget.videoController?.addListener(_onVideoTick);
+    }
+
+    if (oldWidget.recording.streamId != widget.recording.streamId) {
+      _resetForNewRecording();
+      if (widget.isActive) {
+        unawaited(_loadMessages());
+      }
+      return;
+    }
+
+    if (!oldWidget.isActive && widget.isActive) {
+      if (_allMessages.isEmpty) {
+        unawaited(_loadMessages());
+      } else {
+        _syncVisibleMessages(force: true);
+      }
+    }
+  }
+
+  void _resetForNewRecording() {
+    _loadGeneration++;
+    _allMessages = const [];
+    _visibleMessages = const [];
+    _fallbackStartTime = null;
+    _previousVisibleCount = 0;
+    _isLoading = false;
+  }
+
+  void _onScroll() {
+    if (!_scrollController.hasClients) return;
+    final position = _scrollController.position;
+    const bottomThresholdPx = 80.0;
+    _isAtBottom =
+        position.maxScrollExtent - position.pixels <= bottomThresholdPx;
+  }
+
+  void _onVideoTick() {
+    if (!widget.isActive) return;
+    _syncVisibleMessages();
+  }
+
+  Future<void> _loadMessages() async {
+    final streamId = widget.recording.streamId;
+    if (streamId.isEmpty) return;
+
+    final generation = ++_loadGeneration;
+    if (mounted) {
+      setState(() => _isLoading = true);
+    }
+
+    try {
+      final messages = await IsmLiveRecordingChatHelper.fetchAllChatMessages(
+        streamId: streamId,
+        hostUserId: widget.recording.userId,
+        currentUserId: widget.config.getCurrentUserId?.call(),
+      );
+
+      if (!mounted || generation != _loadGeneration) return;
+
+      _allMessages = messages
+          .where((m) => !m.isEvent && m.streamId == streamId)
+          .toList();
+
+      if (_resolveConfiguredStartTime() == null && _allMessages.isNotEmpty) {
+        _fallbackStartTime = _allMessages.first.timeStamp;
+      }
+
+      _syncVisibleMessages(force: true);
+    } finally {
+      if (mounted && generation == _loadGeneration) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  DateTime? _resolveConfiguredStartTime() => ismLiveRecordingStreamStartTime(
+        widget.recording,
+        widget.config,
+      );
+
+  DateTime? _effectiveStartTime() =>
+      _resolveConfiguredStartTime() ?? _fallbackStartTime;
+
+  void _syncVisibleMessages({bool force = false}) {
+    if (!mounted) return;
+
+    final startTime = _effectiveStartTime();
+    List<IsmLiveChatModel> next;
+
+    if (startTime == null || _allMessages.isEmpty) {
+      next = startTime == null && _allMessages.isNotEmpty
+          ? List<IsmLiveChatModel>.from(_allMessages)
+          : const [];
+    } else {
+      final controller = widget.videoController;
+      final position = controller != null && controller.value.isInitialized
+          ? controller.value.position
+          : Duration.zero;
+      final cutoffMs =
+          startTime.millisecondsSinceEpoch + position.inMilliseconds;
+      next = _allMessages
+          .where(
+            (m) => m.timeStamp.millisecondsSinceEpoch <= cutoffMs,
+          )
+          .toList();
+    }
+
+    final countChanged = next.length != _visibleMessages.length;
+    final tailChanged = next.isNotEmpty &&
+        (_visibleMessages.isEmpty ||
+            next.last.messageId != _visibleMessages.last.messageId);
+
+    if (!force && !countChanged && !tailChanged) {
+      return;
+    }
+
+    final delta = next.length - _previousVisibleCount;
+    _previousVisibleCount = next.length;
+    _visibleMessages = next;
+    setState(() {});
+
+    if (delta > 0 && _isAtBottom) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || !_scrollController.hasClients) return;
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 200),
+          curve: Curves.easeOut,
+        );
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _loadGeneration++;
+    _scrollController.removeListener(_onScroll);
+    _scrollController.dispose();
+    widget.videoController?.removeListener(_onVideoTick);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading && _visibleMessages.isEmpty) {
+      return const SizedBox.shrink();
+    }
+    if (_visibleMessages.isEmpty) {
+      return const SizedBox.shrink();
+    }
+
+    final maxHeight = IsmLiveDimens.percentHeight(0.35);
+
+    return Positioned(
+      left: 8,
+      right: 72,
+      bottom: MediaQuery.paddingOf(context).bottom + 88,
+      child: ShaderMask(
+        shaderCallback: (rect) => const LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            Colors.transparent,
+            Colors.white,
+            Colors.white,
+          ],
+          stops: [0.0, 0.1, 1.0],
+        ).createShader(rect),
+        blendMode: BlendMode.dstIn,
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: maxHeight,
+            maxWidth: MediaQuery.sizeOf(context).width * 0.75,
+          ),
+          child: ListView.builder(
+            controller: _scrollController,
+            padding: IsmLiveDimens.edgeInsets0_8,
+            shrinkWrap: true,
+            itemCount: _visibleMessages.length,
+            itemBuilder: (context, index) {
+              final message = _visibleMessages[index];
+              final screenConfigure = IsmLiveDelegate.streamScreenConfigure;
+              final customBackgroundColor =
+                  screenConfigure.chatItemBgColorCallback?.call(message);
+
+              final defaultMessageWidget = _RecordingChatMessageItem(
+                message: message,
+                backgroundColor: customBackgroundColor,
+              );
+
+              return screenConfigure.chatMessageBuilder?.call(
+                    context,
+                    message,
+                    defaultMessageWidget,
+                  ) ??
+                  defaultMessageWidget;
+            },
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _RecordingChatMessageItem extends StatelessWidget {
+  const _RecordingChatMessageItem({
+    required this.message,
+    this.backgroundColor,
+  });
+
+  final IsmLiveChatModel message;
+  final Color? backgroundColor;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.only(bottom: 10),
+        child: Align(
+          alignment: Alignment.centerLeft,
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              maxWidth: MediaQuery.of(context).size.width * 0.7,
+            ),
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: backgroundColor ?? Colors.black26,
+                borderRadius: BorderRadius.circular(IsmLiveDimens.ten),
+              ),
+              child: Padding(
+                padding: IsmLiveDimens.edgeInsets8_4,
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    IsmLiveImage.network(
+                      IsmLiveDelegate.getUserProfileUrl
+                              ?.call(message.imageUrl) ??
+                          message.imageUrl,
+                      name: message.userName,
+                      initials: message.profileInitials,
+                      dimensions: IsmLiveDimens.twentyFour,
+                      isProfileImage: true,
+                    ),
+                    IsmLiveDimens.boxWidth4,
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Row(
+                            crossAxisAlignment: CrossAxisAlignment.center,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Flexible(
+                                child: Text(
+                                  '${message.displayName}${message.sentByMe ? " (You)" : ""}',
+                                  style: Theme.of(context)
+                                      .textTheme
+                                      .labelSmall!
+                                      .copyWith(
+                                    color: IsmLiveColors.white,
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                  overflow: TextOverflow.ellipsis,
+                                ),
+                              ),
+                              if (message.sentByHost) ...[
+                                IsmLiveDimens.boxWidth8,
+                                DecoratedBox(
+                                  decoration: BoxDecoration(
+                                    color: (context.liveTheme?.primaryColor ??
+                                            IsmLiveColors.primary)
+                                        .withValues(alpha: 0.2),
+                                    borderRadius: BorderRadius.circular(
+                                        IsmLiveDimens.four),
+                                  ),
+                                  child: Padding(
+                                    padding: IsmLiveDimens.edgeInsets6_2,
+                                    child: Text(
+                                      'Host',
+                                      style: Theme.of(context)
+                                          .textTheme
+                                          .labelSmall
+                                          ?.copyWith(
+                                        color: IsmLiveColors.white
+                                            .withValues(alpha: 0.7),
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ],
+                          ),
+                          if (message.isDeleted)
+                            Text(
+                              ' ${message.body} Deleted Message',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .labelSmall
+                                  ?.copyWith(
+                                color: Colors.white70,
+                                fontStyle: FontStyle.italic,
+                              ),
+                            )
+                          else ...[
+                            if (message.isReply &&
+                                message.parentBody != null) ...[
+                              Text(
+                                'Reply to ${message.parentBody}',
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .labelSmall
+                                    ?.copyWith(
+                                  color: Colors.white70,
+                                  fontStyle: FontStyle.italic,
+                                ),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ],
+                            Text(
+                              message.body,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .labelMedium
+                                  ?.copyWith(
+                                color: IsmLiveColors.white,
+                              ),
+                              softWrap: true,
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+}

--- a/lib/src/views/stream_recording/widgets/widgets.dart
+++ b/lib/src/views/stream_recording/widgets/widgets.dart
@@ -1,6 +1,7 @@
 export 'bottom_controls_widget.dart';
 export 'bottom_sheet/bottom_sheet.dart';
 export 'center_play_button_widget.dart';
+export 'recording_chat_overlay.dart';
 export 'right_controls_widget.dart';
 export 'top_controls_widget.dart';
 export 'video_player_widget.dart';


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces chat replay functionality for recorded streams. It adds configuration options to enable chat overlay during playback, including the ability to resolve stream start times when not directly available from recording metadata. The implementation fetches and displays chat messages in sync with video playback, supporting archived and inactive streams, and provides a read-only chat overlay that scrolls automatically with the video position. Additionally, the UI is updated to include the chat overlay widget, enhancing the user experience by allowing viewers to see comments in context during replay.
<!-- kody-pr-summary:end -->